### PR TITLE
Use https protocol

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ ADD requirements.txt /webodm/
 RUN pip install -r requirements.txt
 
 # swagger_spec_validator is not up to date, fetch directly from github
-RUN pip install --upgrade git+git://github.com/Yelp/swagger_spec_validator
+RUN pip install --upgrade git+https://github.com/Yelp/swagger_spec_validator
 
 # Add repository files
 ADD . /webodm/


### PR DESCRIPTION
There is a higher likelihood of `git://` being blocked by a proxy or firewall than `https://`