### PR TITLE
Added friendly message for tasks that fail due to Killed or MemoryError

### DIFF
--- a/app/static/app/js/Console.jsx
+++ b/app/static/app/js/Console.jsx
@@ -15,6 +15,7 @@ class Console extends React.Component {
 
     if (typeof props.children === "string"){
       this.state.lines = props.children.split('\n');
+      if (this.props.onAddLines) this.props.onAddLines(this.state.lines);
     }
 
     this.autoscroll = props.autoscroll === true;
@@ -96,6 +97,7 @@ class Console extends React.Component {
       lines: {$push: lines}
     }));
     this.checkAutoscroll();
+    if (this.props.onAddLines) this.props.onAddLines(lines);
   }
 
   render() {

--- a/app/static/app/js/css/TaskListItem.scss
+++ b/app/static/app/js/css/TaskListItem.scss
@@ -59,9 +59,9 @@
         padding-bottom: 16px;
         padding-left: 16px;
 
-        .geotiff-warning{
+        .task-warning{
             margin-top: 16px;
-            i.fa{
+            i.fa.fa-warning{
                 color: #ff8000;
             }
             span{


### PR DESCRIPTION
When a Task fails and the console contains the strings "Killed" or "MemoryError", the UI now displays a friendlier message:

![image](https://cloud.githubusercontent.com/assets/1951843/24373733/498d6298-1300-11e7-9e99-cda567a0348a.png)

Solves #131 

I plan to merge these changes by Wednesday. Let me know if there's feedback / suggestions!