### PR TITLE
Added support for enum types on task options

### DIFF
--- a/app/static/app/js/Console.jsx
+++ b/app/static/app/js/Console.jsx
@@ -15,7 +15,7 @@ class Console extends React.Component {
 
     if (typeof props.children === "string"){
       this.state.lines = props.children.split('\n');
-      if (this.props.onAddLines) this.props.onAddLines(this.state.lines);
+      if (props.onAddLines) props.onAddLines(this.state.lines);
     }
 
     this.autoscroll = props.autoscroll === true;

--- a/app/static/app/js/css/ProcessingNodeOption.scss
+++ b/app/static/app/js/css/ProcessingNodeOption.scss
@@ -11,4 +11,8 @@
         margin-left: 0;
         margin-right: 0;
     }
+
+    select.form-control{
+        min-width: 204px;
+    }
 }


### PR DESCRIPTION
This PR takes care of #129 . Enum values and the <select> control will only show with the latest node-OpenDroneMap changes.

These changes do not break older behavior and with older versions of node-OpenDroneMap WebODM will continue to show a normal textbox.

Feedback is welcome, I plan to merge these by Thursday.