### PR TITLE
Add ability to run as a systemd service on linux servers easily.

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,46 @@ If you want to run WebODM in production, make sure to change the `SECRET_KEY` va
 
 See the [API documentation page](https://opendronemap.github.io/WebODM/).
 
+## Run the docker version as a Linux Service
+
+If you wish to run the docker version with auto start/monitoring/stop, etc, as a systemd style Linux Service, a systemd unit file is included in the service folder of the repo.
+
+The following pre-requisites are required:
+ * Requires odm user
+ * Requires docker installed via system (ubuntu: apt-get install docker.io)
+ * Requires screen to be installed
+ * Requires odm user member of docker group
+ * Required WebODM directory checked out to /opt/WebODM
+ * Requires that /opt/WebODM is recursively owned by odm:odm
+
+If all pre-requisites have been met, and repository is checked out to /opt/WebODM folder, then you can use the following steps to enable and manage the service:
+
+First, to install the service, and enable the service to run at startup from now on:
+```bash
+systemctl enable /opt/WebODM/service/webodm.service
+```
+
+To manually stop the service:
+```bash
+systemctl stop webodm
+```
+
+To manually start the service:
+```bash
+systemctl start webodm
+```
+
+To manually check service status:
+```bash
+systemctl status webodm
+```
+
+The service runs within a screen session, so as the odm user you can easily jump into the screen session by using:
+```bash
+screen -r webodm
+```
+(if you wish to exit the screen session, don't use ctrl+c, that will kill webodm, use `CTRL+A` then hit the `D` key)
+
 ## Run it natively
 
 If you want to run WebODM natively, you will need to install:

--- a/README.md
+++ b/README.md
@@ -81,10 +81,12 @@ See the [API documentation page](https://opendronemap.github.io/WebODM/).
 ## Run the docker version as a Linux Service
 
 If you wish to run the docker version with auto start/monitoring/stop, etc, as a systemd style Linux Service, a systemd unit file is included in the service folder of the repo.
+This should work on any Linux OS capable of running WebODM, and using a SystemD based service daemon (such as Ubuntu 16.04 server for example).
+This has only been tested on Ubuntu 16.04 server.
 
 The following pre-requisites are required:
  * Requires odm user
- * Requires docker installed via system (ubuntu: apt-get install docker.io)
+ * Requires docker installed via system (ubuntu: `sudo apt-get install docker.io`)
  * Requires screen to be installed
  * Requires odm user member of docker group
  * Required WebODM directory checked out to /opt/WebODM
@@ -94,27 +96,27 @@ If all pre-requisites have been met, and repository is checked out to /opt/WebOD
 
 First, to install the service, and enable the service to run at startup from now on:
 ```bash
-systemctl enable /opt/WebODM/service/webodm.service
+sudo systemctl enable /opt/WebODM/service/webodm.service
 ```
 
 To manually stop the service:
 ```bash
-systemctl stop webodm
+sudo systemctl stop webodm
 ```
 
 To manually start the service:
 ```bash
-systemctl start webodm
+sudo systemctl start webodm
 ```
 
 To manually check service status:
 ```bash
-systemctl status webodm
+sudo systemctl status webodm
 ```
 
 The service runs within a screen session, so as the odm user you can easily jump into the screen session by using:
 ```bash
-screen -r webodm
+sudo screen -r webodm
 ```
 (if you wish to exit the screen session, don't use ctrl+c, that will kill webodm, use `CTRL+A` then hit the `D` key)
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,9 @@ See the [API documentation page](https://opendronemap.github.io/WebODM/).
 ## Run the docker version as a Linux Service
 
 If you wish to run the docker version with auto start/monitoring/stop, etc, as a systemd style Linux Service, a systemd unit file is included in the service folder of the repo.
+
 This should work on any Linux OS capable of running WebODM, and using a SystemD based service daemon (such as Ubuntu 16.04 server for example).
+
 This has only been tested on Ubuntu 16.04 server.
 
 The following pre-requisites are required:
@@ -116,7 +118,7 @@ sudo systemctl status webodm
 
 The service runs within a screen session, so as the odm user you can easily jump into the screen session by using:
 ```bash
-sudo screen -r webodm
+screen -r webodm
 ```
 (if you wish to exit the screen session, don't use ctrl+c, that will kill webodm, use `CTRL+A` then hit the `D` key)
 

--- a/service/webodm.service
+++ b/service/webodm.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Start WebODM OpenDroneMap Service Container
+Requires=docker.service
+
+[Service]
+Type=forking
+User=odm
+Group=odm
+WorkingDirectory=/opt/WebODM
+ExecStart=/bin/bash -c 'screen -dmS webodm /opt/WebODM/webodm.sh start'
+ExecStop=/bin/bash -c '/opt/WebODM/webodm.sh stop'
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
I've added a linux systemd unit file, and instructions on it's installation/use to the readme. This is tested on Ubuntu 16.04 server, and works great to auto start/stop the service running within the docker container, rather than requiring native installation (with manual pre-req handling).