### PR TITLE
change permissions on init-db.sql to prevent permissions error on build

### DIFF
--- a/db/Dockerfile
+++ b/db/Dockerfile
@@ -12,3 +12,4 @@ RUN apt-get update \
 
 EXPOSE 5432
 COPY init.sql /docker-entrypoint-initdb.d/init-db.sql
+RUN chmod 644 /docker-entrypoint-initdb.d/init-db.sql


### PR DESCRIPTION
Permission change to init-db.sql after copy to prevent this error: https://gist.github.com/mspringfield/d72a61d20149d43088f6d26425072500 