### PR TITLE
Remove 'Delete a task' from docs

### DIFF
--- a/index.html
+++ b/index.html
@@ -658,12 +658,6 @@ as soon as a <a href="#processing-node">Processing Node</a> is available. It is 
 
 <p>Parameters are the same as above.</p>
 
-<h3 id="delete-a-task">Delete a task</h3>
-
-<p><code class="prettyprint">DELETE /api/projects/{project_id}/tasks/{task_id}/</code></p>
-
-<p>Upon deletion, all images and assets associated with the <a href="#task">Task</a> are deleted also. The operation is irreversible.</p>
-
 <h3 id="get-list-of-tasks">Get list of tasks</h3>
 
 <blockquote>


### PR DESCRIPTION
Removed 'Delete a task' from the docs, since using 'Remove a task' is the right way.