### PR TITLE
Increased timeout values for gunicorn/nginx

### DIFF
--- a/nginx/nginx-ssl.conf.template
+++ b/nginx/nginx-ssl.conf.template
@@ -46,7 +46,7 @@ http {
 
     keepalive_timeout 5;
 
-    proxy_connect_timeout 300000s;
+    proxy_connect_timeout 60s;
     proxy_read_timeout 300000s;
 
     # path for static files

--- a/nginx/nginx-ssl.conf.template
+++ b/nginx/nginx-ssl.conf.template
@@ -46,8 +46,8 @@ http {
 
     keepalive_timeout 5;
 
-    proxy_connect_timeout 360s;
-    proxy_read_timeout 360s;
+    proxy_connect_timeout 300000s;
+    proxy_read_timeout 300000s;
 
     # path for static files
     location /static {

--- a/nginx/nginx.conf.template
+++ b/nginx/nginx.conf.template
@@ -35,7 +35,7 @@ http {
 
     keepalive_timeout 5;
 
-    proxy_connect_timeout 300000s;
+    proxy_connect_timeout 60s;
     proxy_read_timeout 300000s;
 
     # path for static files

--- a/nginx/nginx.conf.template
+++ b/nginx/nginx.conf.template
@@ -35,8 +35,8 @@ http {
 
     keepalive_timeout 5;
 
-    proxy_connect_timeout 360s;
-    proxy_read_timeout 360s;
+    proxy_connect_timeout 300000s;
+    proxy_read_timeout 300000s;
 
     # path for static files
     location /static {

--- a/start.sh
+++ b/start.sh
@@ -113,7 +113,7 @@ else
     congrats
 
     nginx -c $(pwd)/nginx/$conf
-    gunicorn webodm.wsgi --bind unix:/tmp/gunicorn.sock --timeout 360 --max-requests 250 --preload
+    gunicorn webodm.wsgi --bind unix:/tmp/gunicorn.sock --timeout 300000 --max-requests 250 --preload
 fi
 
 # If this is executed, it means the previous command failed, don't display the congratulations message


### PR DESCRIPTION
Fixes #353 

3 days should be sufficient to do file uploads.