### PR TITLE
Up the recommended minimum overlap + 3D rec

### DIFF
--- a/app/templates/app/dashboard.html
+++ b/app/templates/app/dashboard.html
@@ -34,7 +34,8 @@
 			<p>
 				<ul>
 					<li>{% trans 'You need at least 5 images' %}</li>
-					<li>{% trans 'Images must overlap by 60% or more' %}</li>
+					<li>{% trans 'Images must overlap by 65% or more' %}</li>
+					<li>{% trans 'For great 3D, images must overlap by 83%' %}</li>
 					<li>{% trans 'A <a href="https://github.com/OpenDroneMap/OpenDroneMap/wiki/Running-OpenDroneMap#running-odm-with-ground-control" target="_blank">GCP file</a> is optional, but can increase georeferencing accuracy' %}</li>
 				</ul>
 			</p>


### PR DESCRIPTION
Recommended overlap should be a little higher-- 65% guarantees 8 images per location, which is a better practice. I also added a recommendation for great 3D which is 83% overlap.