### PR TITLE
Support for enabling / disabling / adding plugins without rebuilding containers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,4 @@ pip-selfcheck.json
 .idea/
 package-lock.json
 .cronenv
+.initialized

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ A free, user-friendly, extendable application and [API](http://docs.webodm.org) 
     * [Common Troubleshooting](#common-troubleshooting)
     * [Backup and Restore](#backup-and-restore)
     * [Reset Password](#reset-password)
+    * [Manage Plugins](#manage-plugins)
  * [Customizing and Extending](#customizing-and-extending)
  * [API Docs](#api-docs)
  * [OpenDroneMap, node-OpenDroneMap, WebODM... what?](#opendronemap-node-opendronemap-webodm-what)
@@ -158,6 +159,24 @@ If you forgot the password you picked the first time you logged into WebODM, to 
 ```
 
 The password will be reset to `newpass`. The command will also tell you what username you chose.
+
+### Manage Plugins
+
+To list all available plugins type:
+
+```bash
+./webodm.sh plugin list
+```
+
+To enable/disable a plugin type:
+
+```bash
+./webodm.sh plugin enable <plugin name>
+./webodm.sh plugin disable <plugin name>
+./webodm.sh restart
+```
+
+On some platforms (eg. Windows), if you want to manage plugins, you will need to make sure that the `./plugins` directory can be mounted as a docker volume and then pass the `--mount-plugins-volume` flag to `webodm.sh`. Check the docker documentation.
 
 ## Customizing and Extending
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ A free, user-friendly, extendable application and [API](http://docs.webodm.org) 
 
 * From the Docker Quickstart Terminal or Powershell (Windows), or from the command line (Mac / Linux), type:
 ```bash
-git clone https://github.com/OpenDroneMap/WebODM --config core.autocrlf=input
+git clone https://github.com/OpenDroneMap/WebODM --config core.autocrlf=input --depth 1
 cd WebODM
 ./webodm.sh start
 ```
@@ -350,7 +350,7 @@ brew install postgres postgis
 Then these steps should be sufficient to get you up and running:
 
 ```bash
-git clone https://github.com/OpenDroneMap/WebODM
+git clone --depth 1 https://github.com/OpenDroneMap/WebODM
 ```
 
 Create a `WebODM/webodm/local_settings.py` file containing your database settings:

--- a/docker-compose.plugins.yml
+++ b/docker-compose.plugins.yml
@@ -1,0 +1,8 @@
+version: '2.1'
+services:
+  webapp:
+    volumes:
+      - ./plugins:/webodm/plugins
+  worker:
+    volumes:
+      - ./plugins:/webodm/plugins

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "WebODM",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Open Source Drone Image Processing",
   "main": "index.js",
   "scripts": {

--- a/plugins/.gitignore
+++ b/plugins/.gitignore
@@ -1,1 +1,2 @@
 webpack.config.js
+disabled

--- a/start.sh
+++ b/start.sh
@@ -51,8 +51,11 @@ if [ "$1" = "--setup-devenv" ] || [ "$2" = "--setup-devenv" ]; then
     webpack --watch &
 fi
 
-echo Cleaning up plugins
-./webodm.sh plugin cleanup
+if [[ ! -e .initialized ]]; then
+    echo Cleaning up plugins
+    ./webodm.sh plugin cleanup
+    touch .initialized
+fi
 
 echo Running migrations
 python manage.py migrate

--- a/start.sh
+++ b/start.sh
@@ -51,6 +51,9 @@ if [ "$1" = "--setup-devenv" ] || [ "$2" = "--setup-devenv" ]; then
     webpack --watch &
 fi
 
+echo Cleaning up plugins
+./webodm.sh plugin cleanup
+
 echo Running migrations
 python manage.py migrate
 
@@ -74,11 +77,25 @@ cat app/scripts/unlock_all_tasks.py | python manage.py shell
 
 congrats(){
     (sleep 5; echo
-    echo -e "\033[92m"      
-    echo "Congratulations! └@(･◡･)@┐"
-    echo ==========================
-    echo -e "\033[39m"
-    echo "If there are no errors, WebODM should be up and running!"
+
+    echo "Trying to establish communication..."
+    status=$(curl --max-time 300 -L -s -o /dev/null -w "%{http_code}" "$proto://localhost:8000")
+
+    if [[ "$status" = "200" ]]; then
+        echo -e "\033[92m"      
+        echo "Congratulations! └@(･◡･)@┐"
+        echo ==========================
+        echo -e "\033[39m"
+        echo "If there are no errors, WebODM should be up and running!"
+    else    
+        echo -e "\033[93m"
+        echo "Something doesn't look right! ¯\_(ツ)_/¯"
+        echo "The server returned a status code of $status when we tried to reach it."
+        echo ==========================
+        echo -e "\033[39m"
+        echo "Check if WebODM is running, maybe we tried to reach it too soon."
+    fi
+
     echo -e "\033[93m"
     echo Open a web browser and navigate to $proto://$WO_HOST:$WO_PORT
     echo -e "\033[39m"

--- a/webodm.sh
+++ b/webodm.sh
@@ -256,7 +256,7 @@ rebuild(){
 
 plugin_cleanup(){
     # Delete all node_modules and build directories within plugins' public/ folders
-    find plugins/ -type d \( -name build -o -name node_modules \) -path 'plugins/*/public/*' -exec rm -frv '{}' \; 2>/dev/null
+    find plugins/ -type d \( -name build -o -name node_modules \) -path 'plugins/*/public/*' -exec rm -frv '{}' \;
 }
 
 plugin_list(){

--- a/webodm.sh
+++ b/webodm.sh
@@ -246,7 +246,7 @@ down(){
 
 rebuild(){
 	run "docker-compose down --remove-orphans"
-    plugin_cleanup
+	plugin_cleanup
 	run "rm -fr node_modules/ || sudo rm -fr node_modules/"
 	run "rm -fr nodeodm/external/node-OpenDroneMap || sudo rm -fr nodeodm/external/node-OpenDroneMap"
 	run "docker-compose -f docker-compose.yml -f docker-compose.build.yml build --no-cache"

--- a/webodm.sh
+++ b/webodm.sh
@@ -98,7 +98,12 @@ usage(){
   echo "	rebuild			Rebuild all docker containers and perform cleanups"
   echo "	checkenv		Do an environment check and install missing components"
   echo "	test			Run the unit test suite (developers only)"
-  echo "	resetadminpassword <newpassword>	Reset the administrator's password to a new one. WebODM must be running when executing this command."
+  echo "	resetadminpassword <new password>	Reset the administrator's password to a new one. WebODM must be running when executing this command."
+  echo ""
+  echo "	plugin enable <plugin name>	Enable a plugin"
+  echo "	plugin disable <plugin name>	Disable a plugin"
+  echo "	plugin list		List all available plugins"
+  echo "	plugin cleanup		Cleanup plugins build directories"
   echo ""
   echo "Options:"
   echo "	--port	<port>	Set the port that WebODM should bind to (default: $DEFAULT_PORT)"
@@ -218,11 +223,60 @@ down(){
 
 rebuild(){
 	run "docker-compose down --remove-orphans"
+    plugin_cleanup
 	run "rm -fr node_modules/ || sudo rm -fr node_modules/"
 	run "rm -fr nodeodm/external/node-OpenDroneMap || sudo rm -fr nodeodm/external/node-OpenDroneMap"
 	run "docker-compose -f docker-compose.yml -f docker-compose.build.yml build --no-cache"
 	#run "docker images --no-trunc -aqf \"dangling=true\" | xargs docker rmi"
 	echo -e "\033[1mDone!\033[0m You can now start WebODM by running $0 start"
+}
+
+plugin_cleanup(){
+    # Delete all node_modules and build directories within plugins' public/ folders
+    find plugins/ -type d \( -name build -o -name node_modules \) -path 'plugins/*/public/*' -exec rm -frv '{}' \; 2>/dev/null
+}
+
+plugin_list(){
+    plugins=$(ls plugins/ --hide test)
+    for plugin in $plugins; do
+        if [ -e "plugins/$plugin/disabled" ]; then
+            echo "$plugin [disabled]"
+        else
+            echo "$plugin"
+        fi
+    done
+}
+
+plugin_check(){
+    plugin_name="$1"
+    if [ ! -e "plugins/$plugin_name" ]; then
+        echo "Plugin $plugin_name does not exist."
+        exit 1
+    fi
+}
+
+plugin_enable(){
+    plugin_name="$1"
+    plugin_check $plugin_name
+
+    if [ -e "plugins/$plugin_name/disabled" ]; then
+        rm "plugins/$plugin_name/disabled"
+        echo "Plugin enabled. Run ./webodm.sh restart to apply the changes."
+    else
+        echo "Plugin already enabled."
+    fi
+}
+
+plugin_disable(){
+    plugin_name="$1"
+    plugin_check $plugin_name
+
+    if [ ! -e "plugins/$plugin_name/disabled" ]; then
+        touch "plugins/$plugin_name/disabled"
+        echo "Plugin disabled. Run ./webodm.sh restart to apply the changes."
+    else
+        echo "Plugin already disabled."
+    fi
 }
 
 run_tests(){
@@ -291,6 +345,26 @@ elif [[ $1 = "test" ]]; then
 	run_tests
 elif [[ $1 = "resetadminpassword" ]]; then
 	resetpassword $2
+elif [[ $1 = "plugin" ]]; then
+    if [[ $2 = "cleanup" ]]; then
+        plugin_cleanup
+    elif [[ $2 = "list" ]]; then
+        plugin_list
+    elif [[ $2 = "enable" ]]; then
+        if [[ ! -z "$3" ]]; then
+            plugin_enable $3
+        else
+            usage
+        fi
+    elif [[ $2 = "disable" ]]; then
+        if [[ ! -z "$3" ]]; then
+            plugin_disable $3
+        else
+            usage
+        fi
+    else
+        usage
+    fi
 else
 	usage
 fi


### PR DESCRIPTION
As the title says, available out of the box on supported platforms (Linux and most macOS manual installations) and with some configuration work via `./webodm.sh [command] --mount-plugins-volume` on unsupported ones.

Still need to write some documentation and perform some testing before merging.