### PR TITLE
Updated plugin code to work with newer webpack

### DIFF
--- a/app/static/app/js/classes/plugins/ApiFactory.js
+++ b/app/static/app/js/classes/plugins/ApiFactory.js
@@ -39,6 +39,13 @@ export default class ApiFactory{
           this.events.addListener(`${api.namespace}::${eventName}`, args => {
             Promise.all(callbackOrDeps.map(dep => SystemJS.import(dep)))
               .then((...deps) => {
+                
+                // For each dependency, see if it exports a default module (ES6 style)
+                // if it does, export just the default module, otherwise export all modules
+                deps = deps.map(dep => {
+                    return dep.map(exp => exp.default ? exp.default : exp);
+                });
+
                 const response = {
                   result: callbackOrUndef(...(Array.from([args]).concat(...deps))),
                   placeholder: args._placeholder

--- a/plugins/measure/public/MeasurePopup.jsx
+++ b/plugins/measure/public/MeasurePopup.jsx
@@ -4,7 +4,7 @@ import './MeasurePopup.scss';
 import $ from 'jquery';
 import L from 'leaflet';
 
-module.exports = class MeasurePopup extends React.Component {
+export default class MeasurePopup extends React.Component {
   static defaultProps = {
     map: {}, 
     model: {},

--- a/plugins/measure/public/app.jsx
+++ b/plugins/measure/public/app.jsx
@@ -7,7 +7,7 @@ import ReactDOM from 'ReactDOM';
 import React from 'react';
 import $ from 'jquery';
 
-module.exports = class App{
+export default class App{
     constructor(map){
         this.map = map;
 

--- a/plugins/openaerialmap/public/ShareButton.jsx
+++ b/plugins/openaerialmap/public/ShareButton.jsx
@@ -5,7 +5,7 @@ import Storage from 'webodm/classes/Storage';
 import ErrorMessage from 'webodm/components/ErrorMessage';
 import $ from 'jquery';
 
-module.exports = class ShareButton extends React.Component{
+export default class ShareButton extends React.Component{
     static defaultProps = {
         task: null,
         token: ""

--- a/plugins/test/public/component.jsx
+++ b/plugins/test/public/component.jsx
@@ -1,5 +1,5 @@
 import React from 'react'; // can import React
 
-module.exports = {
+export default {
     es6func: () => {} // ES6 transpiler works
 };


### PR DESCRIPTION
Fixes a problem with amd vs ES6 style imports in recent versions of webpack, which is currently causing plugins not to initialize properly.