### PR TITLE
Make CORS settings relaxed again (broken due to Django 2.1 update)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ django-appconf==1.0.2
 django-codemirror2==0.2
 django-colorfield==0.1.15
 django-compressor==2.2
-django-cors-headers==2.2.0
+django-cors-headers==3.0.2
 django-filter==2.0.0
 django-guardian==1.4.9
 django-imagekit==4.0.1

--- a/webodm/settings.py
+++ b/webodm/settings.py
@@ -250,6 +250,7 @@ LOGIN_URL = '/login/'
 # CORS (very relaxed settings, users might want to change this in production)
 CORS_ORIGIN_ALLOW_ALL = True
 CORS_ALLOW_CREDENTIALS = True
+SESSION_COOKIE_SAMESITE = None
 
 # File uploads
 MEDIA_ROOT = os.path.join(BASE_DIR, 'app', 'media')


### PR DESCRIPTION
Make CORS relaxed again (it was made more secure in Django 2.1).

```
Note: in Django 2.1 the SESSION_COOKIE_SAMESITE setting was added, set to 'Lax' by default, which will prevent Django's session cookie being sent cross-domain. Change it to None to bypass this security restriction.
```

https://github.com/ottoyiu/django-cors-headers#cors_allow_credentials
