### PR TITLE
Get settings.py through django.conf

### DIFF
--- a/app/plugins/functions.py
+++ b/app/plugins/functions.py
@@ -14,7 +14,7 @@ from django.http import HttpResponse
 
 from app.models import Plugin
 from app.models import Setting
-from webodm import settings
+from django.conf import settings
 
 logger = logging.getLogger('app.logger')
 


### PR DESCRIPTION
The previous "from webodm import settings"  would get the first settings.py
Using django.conf is a better option 
This is discussed in this Stack Overflow topic: https://stackoverflow.com/questions/19976115/whats-the-difference-between-from-django-conf-import-settings-and-import-set
And in the docs: https://docs.djangoproject.com/en/dev/topics/settings/#using-settings-in-python-code