### PR TITLE
[Up for discussion] Running webodm in detached mode

### DIFF
--- a/webodm.sh
+++ b/webodm.sh
@@ -20,6 +20,7 @@ fi
 
 load_default_node=true
 dev_mode=false
+debug_mode=false
 
 # Load default values
 source .env
@@ -73,12 +74,14 @@ case $key in
     ;;
     --debug)
     export WO_DEBUG=YES
+    debug_mode=true
     shift # past argument
     ;;
     --dev)
     export WO_DEBUG=YES
     export WO_DEV=YES
     dev_mode=true
+    debug_mode=true
     shift # past argument
     ;;
 	--broker)
@@ -244,7 +247,11 @@ start(){
 		echo "Will enable SSL ($method)"
 	fi
 
-	run "$command start || $command up"
+	if [[ $debug_mode = true ]]; then
+		run "$command start || $command up"
+	else
+		run "$command start || $command up -d"
+	fi
 }
 
 down(){

--- a/webodm.sh
+++ b/webodm.sh
@@ -20,7 +20,6 @@ fi
 
 load_default_node=true
 dev_mode=false
-debug_mode=false
 
 # Load default values
 source .env
@@ -74,14 +73,12 @@ case $key in
     ;;
     --debug)
     export WO_DEBUG=YES
-    debug_mode=true
     shift # past argument
     ;;
     --dev)
     export WO_DEBUG=YES
     export WO_DEV=YES
     dev_mode=true
-    debug_mode=true
     shift # past argument
     ;;
 	--broker)
@@ -95,6 +92,10 @@ case $key in
     ;;
     --with-micmac)
     load_micmac_node=true
+    shift # past argument
+    ;;
+    --detached)
+    detached=true
     shift # past argument
     ;;
     *)    # unknown option
@@ -133,6 +134,7 @@ usage(){
   echo "	--debug	Enable debug for development environments (default: disabled)"
   echo "	--dev	Enable development mode. In development mode you can make modifications to WebODM source files and changes will be reflected live. (default: disabled)"
   echo "	--broker	Set the URL used to connect to the celery broker (default: $DEFAULT_BROKER)"
+  echo "	--detached	Run WebODM in detached mode. This means WebODM will run in the background, without blocking the terminal (default: disabled)"
   exit
 }
 
@@ -247,11 +249,13 @@ start(){
 		echo "Will enable SSL ($method)"
 	fi
 
-	if [[ $debug_mode = true ]]; then
-		run "$command start || $command up"
-	else
-		run "$command start || $command up -d"
+	command="$command start || $command up"
+
+	if [[ $detached = true ]]; then
+		command+=" -d"
 	fi
+
+	run "$command"
 }
 
 down(){


### PR DESCRIPTION
Hey ODM maintainers!

I've been having a problem when I start WebODM. If the container doesn't exist, `docker-compose up` creates it, starts it and attaches by default. This causes a few problems when I want to do something else after WebODM starts, since the terminal is blocked.

Also, what is kind of weird, is that if the container is only stopped, `docker-compose start` doesn't attach. So the blocking depends on the state of the container.

My proposal is to only attach if WebODM is run in **debug** or **dev** mode. This would change the current behavior of how WebODM starts. 

If you would like to avoid that, another option could be to add a new flag (maybe `--detached`) that always runs in detached mode. That wouldn't change the current funcionality.

A third option would be to close the PR and run WebODM in the background in the first place, but I thought it might make sense to bring all this up.

What do you think? :smile: 