### PR TITLE
Expose livereload port in dev mode, auto include livereload script

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -2,6 +2,8 @@ version: '2.1'
 services:
   webapp:
     entrypoint: /bin/bash -c "chmod +x /webodm/*.sh && /bin/bash -c \"/webodm/wait-for-postgres.sh db /webodm/wait-for-it.sh -t 0 broker:6379 -- /webodm/start.sh --create-default-pnode --setup-devenv\""
+    ports:
+      - "35729:35729"
     volumes:
       - .:/webodm
   worker:

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -22,7 +22,7 @@ module.exports = {
   },
 
   plugins: [
-    new LiveReloadPlugin(),
+    new LiveReloadPlugin({appendScriptTag: true}),
     new BundleTracker({filename: './webpack-stats.json'}),
     new ExtractTextPlugin('css/[name]-[hash].css', {
         allChunks: true


### PR DESCRIPTION
Fixes #695 (to the extent possible).

Livereload only works for the main code changes. Plugins are not livereloaded (that would involve exposing a port for each plugin since we run webpack for each plugin separately).

Or exposing a `--dev-plugin <name>` option for working on a certain plugin, which could then bind a livereload process only for a certain plugin. This adds some complex logic, but would like to see more contributors interested in this before implementing it (PRs also welcome).