### PR TITLE
Fix Cloud Import: Task Button Is Never Shown

### DIFF
--- a/plugins/cloudimport/manifest.json
+++ b/plugins/cloudimport/manifest.json
@@ -2,7 +2,7 @@
 	"name": "Cloud Import",
 	"webodmMinVersion": "1.1.2",
 	"description": "Import images from external sources directly",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"author": "Nicolas Chamo",
 	"email": "nicolas@chamo.com.ar",
 	"repository": "https://github.com/OpenDroneMap/WebODM",

--- a/plugins/cloudimport/templates/load_buttons.js
+++ b/plugins/cloudimport/templates/load_buttons.js
@@ -11,18 +11,20 @@ PluginsAPI.Dashboard.addNewTaskButton(
 
 PluginsAPI.Dashboard.addTaskActionButton(
 	["cloudimport/build/TaskView.js"],
-	function(args, ImportView) {
+	function(args, TaskView) {
+		var reactElement;
 		$.ajax({
 			url: "{{ api_url }}/projects/" + args.task.project + "/tasks/" + args.task.id + "/checkforurl",
 			dataType: 'json',
 			async: false,
 			success: function(data) {
 				if (data.folder_url) {
-					return React.createElement(ImportView, {
+					reactElement = React.createElement(TaskView, {
 						folderUrl: data.folder_url,
 					});
 				}
 			}
 		});
+		return reactElement;
 	}
 );


### PR DESCRIPTION
Hey @pierotofy!

So in the PR we merged yesterday (https://github.com/OpenDroneMap/WebODM/pull/721), I added a little bug in one of the final changes. 

I basically wasn't returning the react element at any time, so the task button was never shown.

Apparently I hadn't rebuilt WebODM, or it wasn't on dev mode, but it looked like it worked, when it didn't.

I caught the problem today, when I synced my fork with the latest master 😄 