### PR TITLE
fix .env file not found

### DIFF
--- a/webodm.sh
+++ b/webodm.sh
@@ -22,7 +22,7 @@ default_nodes=1
 dev_mode=false
 
 # Load default values
-source .env
+source ${__dirname}/.env
 DEFAULT_PORT="$WO_PORT"
 DEFAULT_HOST="$WO_HOST"
 DEFAULT_MEDIA_DIR="$WO_MEDIA_DIR"


### PR DESCRIPTION
Hi.

I executed this command.
```
$ sh webodm.sh start
```

but I got error, this.
```
$ sh webodm.sh start
webodm.sh: line 26: source: .env: file not found
```
( on `CentOS Linux release 7.6.1810 (Core)` )

so, I fixed that error.

after,
```
$ sh webodm.sh start
Checking for docker...   OK
Checking for git...   OK
Checking for docker-compose...   OK
Starting WebODM...

Using the following environment:
================================
Host: localhost
Port: 8000
Media directory: appmedia
SSL: NO
SSL key:
SSL certificate:
SSL insecure port redirect: 80
Celery Broker: redis://broker
Default Nodes: 1
================================
Make sure to issue a webodm.sh down if you decide to change the environment.
```


Please merge if you like.