### PR TITLE
[docker] fix #758 (containers not restarting on host reboot)

### DIFF
--- a/docker-compose.nodemicmac.yml
+++ b/docker-compose.nodemicmac.yml
@@ -14,5 +14,5 @@ services:
     container_name: node-micmac-1
     ports:
       - "3000"
-    restart: on-failure:10
+    restart: unless-stopped
     oom_score_adj: 500

--- a/docker-compose.nodeodm.yml
+++ b/docker-compose.nodeodm.yml
@@ -13,5 +13,5 @@ services:
     image: opendronemap/nodeodm
     ports:
       - "3000"
-    restart: on-failure:10
+    restart: unless-stopped
     oom_score_adj: 500

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - "5432"
     volumes:
       - dbdata:/var/lib/postgresql/data
-    restart: on-failure:10
+    restart: unless-stopped
     oom_score_adj: -100
   webapp:
     image: opendronemap/webodm_webapp
@@ -32,12 +32,12 @@ services:
       - WO_DEBUG
       - WO_BROKER
       - WO_DEV
-    restart: on-failure:10
+    restart: unless-stopped
     oom_score_adj: 0
   broker:
     image: redis
     container_name: broker
-    restart: on-failure:10
+    restart: unless-stopped
     oom_score_adj: -500
   worker:
     image: opendronemap/webodm_webapp
@@ -51,5 +51,5 @@ services:
     environment:
       - WO_BROKER
       - WO_DEBUG
-    restart: on-failure:10
+    restart: unless-stopped
     oom_score_adj: 250


### PR DESCRIPTION
Fix for #758 where container didn't reboot.

From docker-compose docs :
> unless-stopped : Similar to always, except that when the container is stopped (manually or otherwise), it is not restarted even after Docker daemon restarts.

I also removed the `:10` (that I think is supposed to limit the number of retries), as it is not documented in the docker-compose reference, and not necessarily a good idea (it may prevent the stack from recovering from transient issues such as connectivity issues)

Cheers !