### PR TITLE
Handle errors coming from /api/plugins/openaerialmap/task/{id}/info endpoint

### DIFF
--- a/plugins/openaerialmap/manifest.json
+++ b/plugins/openaerialmap/manifest.json
@@ -2,7 +2,7 @@
 	"name": "OpenAerialMap",
 	"webodmMinVersion": "0.6.0",
 	"description": "A plugin to upload orthophotos to OpenAerialMap",
-	"version": "0.9.0",
+	"version": "0.9.1",
 	"author": "Piero Toffanin",
 	"email": "pt@masseranolabs.com",
 	"repository": "https://github.com/OpenDroneMap/WebODM",

--- a/plugins/openaerialmap/public/ShareButton.jsx
+++ b/plugins/openaerialmap/public/ShareButton.jsx
@@ -31,7 +31,7 @@ export default class ShareButton extends React.Component{
     }
 
     updateTaskInfo = (showErrors) => {
-        const { task } = this.props; 
+        const { task } = this.props;
         return $.ajax({
                 type: 'GET',
                 url: `/api/plugins/openaerialmap/task/${task.id}/info`,
@@ -49,7 +49,7 @@ export default class ShareButton extends React.Component{
                 this.setState({taskInfo, loading: false});
                 if (taskInfo.error && showErrors) this.setState({error: taskInfo.error});
             }).fail(error => {
-                this.setState({error, loading: false});
+                this.setState({error: error.statusText, loading: false});
             });
     }
 
@@ -108,17 +108,19 @@ export default class ShareButton extends React.Component{
     }
 
     render(){
-        const { loading, taskInfo } = this.state;
+        const { loading, taskInfo, error } = this.state;
 
         const getButtonIcon = () => {
             if (loading || taskInfo.sharing) return "fa fa-circle-notch fa-spin fa-fw";
-            else return "oam-icon fa";
+            else if (error) return "fa fa-exclamation-triangle";
+            else return "fa oam-icon";
         };
 
         const getButtonLabel = () => {
             if (loading) return "";
             else if (taskInfo.sharing) return " Sharing...";
             else if (taskInfo.shared) return " View In OAM";
+            else if (error) return " OAM Plugin Error";
             else return " Share To OAM";
         }
 
@@ -126,13 +128,13 @@ export default class ShareButton extends React.Component{
                 <ErrorMessage bind={[this, "error"]} />,
                 <button
                 onClick={this.handleClick}
-                disabled={loading || taskInfo.sharing}
+                disabled={loading || taskInfo.sharing || error}
                 className="btn btn-sm btn-primary">
                     {[<i className={getButtonIcon()}></i>, getButtonLabel()]}
                 </button>];
 
         if (taskInfo.sensor !== undefined){
-            result.unshift(<ShareDialog 
+            result.unshift(<ShareDialog
                   ref={(domNode) => { this.shareDialog = domNode; }}
                   task={this.props.task}
                   taskInfo={taskInfo}


### PR DESCRIPTION
Caused by doing an import of an `all.zip` file:
```
webapp      | ERROR Internal Server Error: /api/plugins/openaerialmap/task/c8dc0f2a-5064-4c51-bc66-ba3c593173c8/info
webapp      | Traceback (most recent call last):
webapp      |   File "/usr/local/lib/python3.6/site-packages/django/core/handlers/exception.py", line 34, in inner
webapp      |     response = get_response(request)
webapp      |   File "/usr/local/lib/python3.6/site-packages/django/core/handlers/base.py", line 126, in _get_response
webapp      |     response = self.process_exception_by_middleware(e, request)
webapp      |   File "/usr/local/lib/python3.6/site-packages/django/core/handlers/base.py", line 124, in _get_response
webapp      |     response = wrapped_callback(request, *callback_args, **callback_kwargs)
webapp      |   File "/usr/local/lib/python3.6/site-packages/django/views/decorators/csrf.py", line 54, in wrapped_view
webapp      |     return view_func(*args, **kwargs)
webapp      |   File "/usr/local/lib/python3.6/site-packages/django/views/generic/base.py", line 68, in view
webapp      |     return self.dispatch(request, *args, **kwargs)
webapp      |   File "/usr/local/lib/python3.6/site-packages/rest_framework/views.py", line 495, in dispatch
webapp      |     response = self.handle_exception(exc)
webapp      |   File "/usr/local/lib/python3.6/site-packages/rest_framework/views.py", line 455, in handle_exception
webapp      |     self.raise_uncaught_exception(exc)
webapp      |   File "/usr/local/lib/python3.6/site-packages/rest_framework/views.py", line 492, in dispatch
webapp      |     response = handler(request, *args, **kwargs)
webapp      |   File "/webodm/plugins/openaerialmap/api.py", line 62, in get
webapp      |     img_path = os.path.join(settings.MEDIA_ROOT, img.path())
webapp      | AttributeError: 'NoneType' object has no attribute 'path'
webapp      | ERROR "GET /api/plugins/openaerialmap/task/c8dc0f2a-5064-4c51-bc66-ba3c593173c8/info HTTP/1.1" 500 19128
```

**Changes:**
~~* `ErrorMessage` component maintains hidden state internally and can display response / error objects, previous these would throw an exception that react can't render them, causing the entire page to go blank.~~
* `ShareButton` is disabled when an error is set and text and icon indicate an error has occurred `OAM Plugin Error` with a hazard icon. Known issue is that if you dismiss the message the button will go back to saying "Share to OAM" and not be disabled, clicking the button does nothing though.

**Screenshot after fix:**
<img width="675" alt="Screen Shot 2020-01-21 at 11 43 32 PM" src="https://user-images.githubusercontent.com/62913/72874901-f1abe200-3ca7-11ea-9e53-3505e6b9276e.png">

Future work in another PR to handle this case in the API and notify the front end properly, rather than with a generic error.

More future work, `ErrorMessage` should be dismissible without clearing the error from the parent component causing it to render as if an error had not occurred.