### PR TITLE
Pin GDAL to latest 2.x version available until 3.x is validated

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN printf "deb     http://ftp.us.debian.org/debian/    stable main contrib non-
 RUN printf "deb     http://ftp.us.debian.org/debian/    testing main contrib non-free\ndeb-src http://ftp.us.debian.org/debian/    testing main contrib non-free" > /etc/apt/sources.list.d/testing.list
 
 # Install Node.js GDAL, nginx, letsencrypt, psql
-RUN apt-get -qq update && apt-get -qq install -t testing -y binutils libproj-dev gdal-bin nginx certbot grass-core && apt-get -qq install -y gettext-base cron postgresql-client-9.6
+RUN apt-get -qq update && apt-get -qq install -t testing -y binutils libproj-dev gdal-bin=2.4.0+dfsg-1+b1 nginx certbot grass-core && apt-get -qq install -y gettext-base cron postgresql-client-9.6
 
 # Install pip reqs
 ADD requirements.txt /webodm/


### PR DESCRIPTION
Fix for #797 should work, not fully tested though.