### PR TITLE
Adjust url to display the tiles in custom baselayer in OSM

### DIFF
--- a/plugins/osm-quickedit/public/main.js
+++ b/plugins/osm-quickedit/public/main.js
@@ -7,7 +7,7 @@ PluginsAPI.Map.addActionButton(function(options){
 		var tile = options.tiles[0];
 		var url = window.location.protocol + "//" + 
 					window.location.host +
-					tile.url.replace(/tiles\.json$/, "tiles/{zoom}/{x}/{ty}.png");
+					tile.url + "tiles/{zoom}/{x}/{y}.png";
 
 		return React.createElement("button", {
 				type: "button",


### PR DESCRIPTION
Adjusted the url to work as a base layer in Open Street map when using the OSM Digitize plugin. #795 