### PR TITLE
fix file upload in selinux enabled environments

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     ports:
       - "5432"
     volumes:
-      - dbdata:/var/lib/postgresql/data
+      - dbdata:/var/lib/postgresql/data:Z
     restart: unless-stopped
     oom_score_adj: -100
   webapp:
@@ -19,7 +19,7 @@ services:
     container_name: webapp
     entrypoint: /bin/bash -c "chmod +x /webodm/*.sh && /bin/bash -c \"/webodm/wait-for-postgres.sh db /webodm/wait-for-it.sh -t 0 broker:6379 -- /webodm/start.sh\""
     volumes:
-      - ${WO_MEDIA_DIR}:/webodm/app/media
+      - ${WO_MEDIA_DIR}:/webodm/app/media:z
     ports:
       - "${WO_PORT}:8000"
     depends_on:
@@ -44,7 +44,7 @@ services:
     container_name: worker
     entrypoint: /bin/bash -c "/webodm/wait-for-postgres.sh db /webodm/wait-for-it.sh -t 0 broker:6379 -- /webodm/wait-for-it.sh -t 0 webapp:8000 -- /webodm/worker.sh start"
     volumes:
-      - ${WO_MEDIA_DIR}:/webodm/app/media
+      - ${WO_MEDIA_DIR}:/webodm/app/media:z
     depends_on:
       - db
       - broker

--- a/webodm/settings.py
+++ b/webodm/settings.py
@@ -258,6 +258,8 @@ if TESTING:
     MEDIA_ROOT = os.path.join(BASE_DIR, 'app', 'media_test')
 MEDIA_TMP = os.path.join(MEDIA_ROOT, 'tmp')
 
+FILE_UPLOAD_TEMP_DIR = MEDIA_TMP
+
 # Store flash messages in cookies
 MESSAGE_STORAGE = 'django.contrib.messages.storage.cookie.CookieStorage'
 MESSAGE_TAGS = {


### PR DESCRIPTION
docker-compose.yml:
	 :z on volume mounts relabels the directory to enable access for all docker container
	 :Z on volume mounts relabels the directory to enable access for this specific docker container
	Some background:
		https://www.projectatomic.io/blog/2015/06/using-volumes-with-docker-can-cause-problems-with-selinux/
		https://docs.docker.com/release-notes/docker-compose/ (-> Syntax introduced in v1.4.0 from 2015-08-04)

	Since these volumes are designed only for use by webodm a relabeling to allow docker containers to have access seems resonable.

webodm/settings.py:
	The change in webodm/settings.py is necessary, because else the webapp will create big upload files in /tmp and move them to the final destination afterwards. Which means they will have container specific MCS context selinux labels applied to them. If the tmp files are created under MEDIA_ROOT, which has the :z labels applied to it, the files will get a label that is accessible from all docker containers.

	Some background:
		https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/selinux_users_and_administrators_guide/sect-security-enhanced_linux-working_with_selinux-selinux_contexts_labeling_files