### PR TITLE
Smooth mesh lighting

### DIFF
--- a/app/static/app/js/vendor/MTLLoader.js
+++ b/app/static/app/js/vendor/MTLLoader.js
@@ -396,7 +396,7 @@ MTLLoader.MaterialCreator.prototype = {
         case 'ks':
 
           // Specular color (color when light is reflected from shiny surface) using RGB values
-          params.specular = new THREE.Color().fromArray( value );
+        //   params.specular = new THREE.Color().fromArray( value );
 
           break;
 
@@ -430,7 +430,7 @@ MTLLoader.MaterialCreator.prototype = {
           // The specular exponent (defines the focus of the specular highlight)
           // A high exponent results in a tight, concentrated highlight. Ns values normally range from 0 to 1000.
 
-          params.shininess = parseFloat( value );
+        //   params.shininess = parseFloat( value );
 
           break;
 
@@ -463,7 +463,7 @@ MTLLoader.MaterialCreator.prototype = {
 
     }
 
-    this.materials[ materialName ] = new THREE.MeshPhongMaterial( params );
+    this.materials[ materialName ] = new THREE.MeshBasicMaterial( params );
     return this.materials[ materialName ];
   },
 


### PR DESCRIPTION
This was confusing some users who complained of low quality polygonal models, when in fact it was a matter of lightning the scene properly in the model viewer. This fixes it.

Before:

![image](https://user-images.githubusercontent.com/1951843/74358026-c0966d00-4d8e-11ea-8af3-cd8a18340e62.png)

After:

![image](https://user-images.githubusercontent.com/1951843/74358037-c429f400-4d8e-11ea-92fd-7d9407d8a434.png)
