### PR TITLE
Force media static files option

### DIFF
--- a/webodm/settings.py
+++ b/webodm/settings.py
@@ -75,6 +75,9 @@ PLUGINS_BLACKLIST = [
     #'measure',
 ]
 
+# Serve media static files URLs even in production
+FORCE_MEDIA_STATICFILES = False
+
 # Application definition
 
 INSTALLED_APPS = [

--- a/webodm/urls.py
+++ b/webodm/urls.py
@@ -28,7 +28,7 @@ urlpatterns = [
     url(r'^admin/', admin.site.urls),
 ]
 
-if settings.DEBUG:
+if settings.DEBUG or settings.FORCE_MEDIA_STATICFILES:
     urlpatterns += [
         # Expose imagekit generated files and settings file uploads
         url(r'^media/CACHE/(?P<path>.*)$', serve, {


### PR DESCRIPTION
Useful during waitress+whitenoise deployments.