### PR TITLE
Super minor fixes to plugins

### DIFF
--- a/plugins/changedetection/public/ChangeDetectionPanel.jsx
+++ b/plugins/changedetection/public/ChangeDetectionPanel.jsx
@@ -31,7 +31,7 @@ export default class ChangeDetectionPanel extends React.Component {
         minArea: Storage.getItem("last_changedetection_min_area") || 40,
         minHeight: Storage.getItem("last_changedetection_min_height") || 5,
         role: Storage.getItem("last_changedetection_role") || 'reference',
-        align: this.props.alignSupported ? (Storage.getItem("last_changedetection_align") || false) : false,
+        align: this.props.alignSupported ? (Storage.getItem("last_changedetection_align") === 'true') : false,
         other: "",
         otherTasksInProject: new Map(),
         loading: true,

--- a/plugins/elevationmap/elevationmap.py
+++ b/plugins/elevationmap/elevationmap.py
@@ -134,7 +134,7 @@ def get_kernel(noise_filter_size, dsm):
         return None
     if dsm.crs.linear_units != 'metre':
         noise_filter_size *= 3.2808333333465 # Convert meter to feets
-    return cv2.getStructuringElement(cv2.MORPH_ELLIPSE, (round(noise_filter_size / dsm.res[0]), round(noise_filter_size / dsm.res[1])))    
+    return cv2.getStructuringElement(cv2.MORPH_ELLIPSE, (int(round(noise_filter_size / dsm.res[0])), int(round(noise_filter_size / dsm.res[1]))))
 
 def assert_same_bounds_and_resolution(dsm, dtm):
     if dtm.bounds != dsm.bounds or dtm.res != dsm.res:


### PR DESCRIPTION
We are making super minor fixes to two different plugins.

First, the change detection plugin. On that case, the stored value is a string. So, we are converting it into a boolean when reading it.

Then, on the elevation map plugin, apparently `round` can return floats in same cases. It was reported on https://community.opendronemap.org/t/problems-with-elevation-map-and-contours-plugins-on-latest-native-build-on-16-04/4171