### PR TITLE
Fix: #873

### DIFF
--- a/app/static/app/js/ModelView.jsx
+++ b/app/static/app/js/ModelView.jsx
@@ -8,6 +8,7 @@ import ShareButton from './components/ShareButton';
 import ImagePopup from './components/ImagePopup';
 import epsg from 'epsg';
 import PropTypes from 'prop-types';
+import * as THREE from 'THREE';
 import $ from 'jquery';
 
 require('./vendor/OBJLoader');
@@ -192,6 +193,7 @@ class ModelView extends React.Component {
     viewer.setEDLEnabled(true);
     viewer.setFOV(60);
     viewer.setPointBudget(1*1000*1000);
+    viewer.setEDLEnabled(false); // Temporary fix: https://github.com/OpenDroneMap/WebODM/issues/873
     viewer.loadSettingsFromURL();
         
     viewer.loadGUI(() => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "WebODM",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "User-friendly, extendable application and API for processing aerial imagery.",
   "main": "index.js",
   "scripts": {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -86,6 +86,7 @@ module.exports = {
     //  on the global let jQuery
     "jquery": "jQuery",
     "SystemJS": "SystemJS",
+    "THREE": "THREE",
     "React": "React",
     "ReactDOM": "ReactDOM"
   },


### PR DESCRIPTION
Disables eye-dome-lighting by default on Potree, which should solve the issue reported in #873. Shoud also take care of a case where THREE is undefined when launching the 3D model view the first time.