### PR TITLE
adjusting python DB settings to use environment variables

### DIFF
--- a/webodm/settings.py
+++ b/webodm/settings.py
@@ -145,12 +145,12 @@ WSGI_APPLICATION = 'webodm.wsgi.application'
 
 DATABASES = {
     'default': {
-        'ENGINE': 'django.contrib.gis.db.backends.postgis',
-        'NAME': 'webodm_dev',
-        'USER': 'postgres',
-        'PASSWORD': 'postgres',
-        'HOST': 'db',
-        'PORT': '5432',
+        'ENGINE': os.environ.get('WO_DATABASE_ENGINE', 'django.contrib.gis.db.backends.postgis')
+        'NAME': os.environ.get('WO_DATABASE_NAME', 'webodm_dev'),
+        'USER': os.environ.get('WO_DATABASE_USER', 'postgres'),
+        'PASSWORD': os.environ.get('WO_DATABASE_PASSWORD', 'postgres'),
+        'HOST': os.environ.get('WO_DATABASE_HOST', 'db'),
+        'PORT': os.environ.get('WO_DATABASE_PORT', '5432'),,
     }
 }
 

--- a/webodm/settings.py
+++ b/webodm/settings.py
@@ -145,7 +145,7 @@ WSGI_APPLICATION = 'webodm.wsgi.application'
 
 DATABASES = {
     'default': {
-        'ENGINE': os.environ.get('WO_DATABASE_ENGINE', 'django.contrib.gis.db.backends.postgis')
+        'ENGINE': os.environ.get('WO_DATABASE_ENGINE', 'django.contrib.gis.db.backends.postgis'),
         'NAME': os.environ.get('WO_DATABASE_NAME', 'webodm_dev'),
         'USER': os.environ.get('WO_DATABASE_USER', 'postgres'),
         'PASSWORD': os.environ.get('WO_DATABASE_PASSWORD', 'postgres'),

--- a/webodm/settings.py
+++ b/webodm/settings.py
@@ -150,7 +150,7 @@ DATABASES = {
         'USER': os.environ.get('WO_DATABASE_USER', 'postgres'),
         'PASSWORD': os.environ.get('WO_DATABASE_PASSWORD', 'postgres'),
         'HOST': os.environ.get('WO_DATABASE_HOST', 'db'),
-        'PORT': os.environ.get('WO_DATABASE_PORT', '5432'),,
+        'PORT': os.environ.get('WO_DATABASE_PORT', '5432'),
     }
 }
 


### PR DESCRIPTION
We are trying to create a WebODM kubernetes deployment.

So in our case we are creating a template, this template generates a pod that contains all the containers running using your mentioned docker-compose files.

The problem is that we need to address the database host in our case with localhost instead of the hard coded db value and maybe external DB in the future

We created a new image and added a hard coded localhost in the python settings to override this problem.

So in order not to keep a separate version of your image, This pull request contains replacing Database env variables while preserving the default values as they are.