### PR TITLE
replacement function of realpath for MacOS

### DIFF
--- a/webodm.sh
+++ b/webodm.sh
@@ -22,9 +22,11 @@ default_nodes=1
 dev_mode=false
 
 # define realpath replacement function
-realpath() {
-    [[ $1 = /* ]] && echo "$1" || echo "$PWD/${1#./}"
-}
+if [[ $platform = "MacOS / OSX" ]]; then
+    realpath() {
+        [[ $1 = /* ]] && echo "$1" || echo "$PWD/${1#./}"
+    }
+fi
 
 # Load default values
 source "${__dirname}/.env"

--- a/webodm.sh
+++ b/webodm.sh
@@ -21,6 +21,11 @@ fi
 default_nodes=1
 dev_mode=false
 
+# define realpath replacement function
+realpath() {
+    [[ $1 = /* ]] && echo "$1" || echo "$PWD/${1#./}"
+}
+
 # Load default values
 source "${__dirname}/.env"
 DEFAULT_PORT="$WO_PORT"


### PR DESCRIPTION
added quick replacement function for realpath, as discussed on [ODM Community](https://community.opendronemap.org/t/media-dir-not-read-in-webodm-sh-start/6628)

i'm not too familiar with shell scripts and i have failed to create a shorthand to handle null realpath values,  such as:
`export WO_MEDIA_DIR=${$(realpath "$2"):-${DEFAULT_MEDIA_DIR}}`

i welcome any suggestions / improvements, as this is my first time actually pushing code to other people's repository.