### PR TITLE
Configurable node offline minutes setting

### DIFF
--- a/app/tests/test_api.py
+++ b/app/tests/test_api.py
@@ -12,8 +12,9 @@ from app.models import Project, Task
 from app.plugins.signals import processing_node_removed
 from app.tests.utils import catch_signal
 from nodeodm import status_codes
-from nodeodm.models import ProcessingNode, OFFLINE_MINUTES
+from nodeodm.models import ProcessingNode
 from .classes import BootTestCase
+from webodm import settings
 
 
 class TestApi(BootTestCase):
@@ -416,7 +417,7 @@ class TestApi(BootTestCase):
                                            last_refreshed=timezone.now(),
                                            available_options=[{'name': 'd'}])
         p4 = ProcessingNode.objects.create(hostname="invalid-host-4", port=11223,
-                                           last_refreshed=timezone.now() - datetime.timedelta(minutes=OFFLINE_MINUTES * 2),
+                                           last_refreshed=timezone.now() - datetime.timedelta(minutes=settings.NODE_OFFLINE_MINUTES * 2),
                                            available_options=[{'name': 'd'}]) # offline
 
         assign_perm('view_processingnode', user, p1)

--- a/app/tests/test_api_task.py
+++ b/app/tests/test_api_task.py
@@ -27,7 +27,7 @@ from app.models.task import task_directory_path, full_task_directory_path, TaskI
 from app.plugins.signals import task_completed, task_removed, task_removing
 from app.tests.classes import BootTransactionTestCase
 from nodeodm import status_codes
-from nodeodm.models import ProcessingNode, OFFLINE_MINUTES
+from nodeodm.models import ProcessingNode
 from app.testwatch import testWatch
 from .utils import start_processing_node, clear_test_media_root, catch_signal
 
@@ -909,7 +909,7 @@ class TestApiTask(BootTransactionTestCase):
         self.assertTrue(task.last_error is not None)
 
         # Bring another processing node online, and bring the old one offline
-        pnode.last_refreshed = timezone.now() - timedelta(minutes=OFFLINE_MINUTES)
+        pnode.last_refreshed = timezone.now() - timedelta(minutes=settings.NODE_OFFLINE_MINUTES)
         pnode.save()
 
         another_pnode.last_refreshed = timezone.now()
@@ -936,7 +936,7 @@ class TestApiTask(BootTransactionTestCase):
         task.last_error = None
         task.status = status_codes.RUNNING
         task.save()
-        another_pnode.last_refreshed = timezone.now() - timedelta(minutes=OFFLINE_MINUTES)
+        another_pnode.last_refreshed = timezone.now() - timedelta(minutes=settings.NODE_OFFLINE_MINUTES)
         another_pnode.save()
 
         worker.tasks.process_pending_tasks()

--- a/nodeodm/models.py
+++ b/nodeodm/models.py
@@ -17,8 +17,6 @@ from django.db.models import signals
 from datetime import timedelta
 
 
-OFFLINE_MINUTES = 5 # Number of minutes a node hasn't been seen before it should be considered offline
-
 class ProcessingNode(models.Model):
     hostname = models.CharField(verbose_name=_("Hostname"), max_length=255, help_text=_("Hostname or IP address where the node is located (can be an internal hostname as well). If you are using Docker, this is never 127.0.0.1 or localhost. Find the IP address of your host machine by running ifconfig on Linux or by checking your network settings."))
     port = models.PositiveIntegerField(verbose_name=_("Port"), help_text=_("Port that connects to the node's API"))
@@ -48,12 +46,12 @@ class ProcessingNode(models.Model):
         Attempts to find an available node (seen in the last 5 minutes, and with lowest queue count)
         :return: ProcessingNode | None
         """
-        return ProcessingNode.objects.filter(last_refreshed__gte=timezone.now() - timedelta(minutes=OFFLINE_MINUTES)) \
+        return ProcessingNode.objects.filter(last_refreshed__gte=timezone.now() - timedelta(minutes=settings.NODE_OFFLINE_MINUTES)) \
                                      .order_by('queue_count').first()
 
     def is_online(self):
         return self.last_refreshed is not None and \
-               self.last_refreshed >= timezone.now() - timedelta(minutes=OFFLINE_MINUTES)
+               self.last_refreshed >= timezone.now() - timedelta(minutes=settings.NODE_OFFLINE_MINUTES)
 
     def update_node_info(self):
         """

--- a/nodeodm/tests.py
+++ b/nodeodm/tests.py
@@ -11,7 +11,7 @@ from os import path
 from pyodm import Node
 from pyodm.exceptions import NodeConnectionError, NodeServerError, NodeResponseError
 from webodm import settings
-from .models import ProcessingNode, OFFLINE_MINUTES
+from .models import ProcessingNode
 from . import status_codes
 
 current_dir = path.dirname(path.realpath(__file__))
@@ -190,7 +190,7 @@ class TestClientApi(TestCase):
         self.assertTrue(ProcessingNode.find_best_available_node().id == another_pnode.id)
 
         # Bring it offline
-        another_pnode.last_refreshed -= timedelta(minutes=OFFLINE_MINUTES)
+        another_pnode.last_refreshed -= timedelta(minutes=settings.NODE_OFFLINE_MINUTES)
         another_pnode.save()
         self.assertFalse(another_pnode.is_online())
 

--- a/webodm/settings.py
+++ b/webodm/settings.py
@@ -366,6 +366,10 @@ CELERY_INCLUDE=['worker.tasks', 'app.plugins.worker']
 CELERY_WORKER_REDIRECT_STDOUTS = False
 CELERY_WORKER_HIJACK_ROOT_LOGGER = False
 
+# Number of minutes a processing node hasn't been seen 
+# before it should be considered offline
+NODE_OFFLINE_MINUTES = 5 
+
 if TESTING or FLUSHING:
     CELERY_TASK_ALWAYS_EAGER = True
 


### PR DESCRIPTION
Allows users to change the number of minutes that elapse before a processing node is marked offline.﻿
