### PR TITLE
Improved performance of camera shot markers 

### DIFF
--- a/app/static/app/js/components/Map.jsx
+++ b/app/static/app/js/components/Map.jsx
@@ -221,11 +221,6 @@ class Map extends React.Component {
 
             // Add camera shots layer if available
             if (meta.task && meta.task.camera_shots && !this.addedCameraShots){
-                const cameraMarker = L.AwesomeMarkers.icon({
-                    icon: 'camera',
-                    markerColor: 'blue',
-                    prefix: 'fa'
-                });
 
                 const shotsLayer = new L.GeoJSON.AJAX(meta.task.camera_shots, {
                     style: function (feature) {
@@ -236,8 +231,12 @@ class Map extends React.Component {
                       }
                     },
                     pointToLayer: function (feature, latlng) {
-                      return L.marker(latlng, {
-                        icon: cameraMarker
+                      return new L.CircleMarker(latlng, {
+                        color: '#3498db',
+                        fillColor: '#3498db',
+                        fillOpacity: 0.9,
+                        radius: 10,
+                        weight: 1
                       });
                     },
                     onEachFeature: function (feature, layer) {


### PR DESCRIPTION
I've processed around 1000 images. I wanted to show camera shot images but the browser struggle in rendering thousands of markers. 
![struggle](https://user-images.githubusercontent.com/23735741/123224114-712c8900-d50c-11eb-9e11-8c5b4a32b9a0.png)
