### PR TITLE
add title to diagnostic page

### DIFF
--- a/coreplugins/diagnostic/plugin.py
+++ b/coreplugins/diagnostic/plugin.py
@@ -42,6 +42,7 @@ class Plugin(PluginBase):
             total_disk_space, used_disk_space, free_disk_space = shutil.disk_usage('./')
 
             template_args = {
+                'title': 'Diagnostic',
                 'total_disk_space': total_disk_space,
                 'used_disk_space': used_disk_space,
                 'free_disk_space': free_disk_space


### PR DESCRIPTION
fixes #1014 

https://github.com/OpenDroneMap/WebODM/blob/master/coreplugins/posm-gcpi/plugin.py#L12
https://github.com/OpenDroneMap/WebODM/blob/master/coreplugins/lightning/plugin.py#L39
the third parameter in the `render()` function on the posm-gcpi and lightning plugin.py files is an object that includes a title key. following those examples to add the title to the Diagnostic page
