### PR TITLE
per #1015 discussion - this removes redundant docker 'start' command

### DIFF
--- a/webodm.sh
+++ b/webodm.sh
@@ -265,7 +265,7 @@ start(){
 		echo "Will enable SSL ($method)"
 	fi
 
-	command="$command start || $command up"
+	command="$command up"
 
 	if [[ $detached = true ]]; then
 		command+=" -d"


### PR DESCRIPTION
Removes redundant docker 'start' command from start function as docker 'up' handles the former.

Issue #1015 

_NOTE: Might be irrelevant considering the type of change but I was unable to test as `--dev` therefore unable to run tests due to the webapp container perpetually restarting when executing start or restart with --dev flag (culprit seemed to be `ModuleNotFoundError: No module named 'rio_tiler'`. I can provide that full specific log if you want._ 