### PR TITLE
Fix potree bug when info.srs is undefined

### DIFF
--- a/app/static/app/js/vendor/potree/build/potree/potree.js
+++ b/app/static/app/js/vendor/potree/build/potree/potree.js
@@ -56837,7 +56837,7 @@
 				this.projection = info.srs.authority + ':' + info.srs.horizontal;
 			}
 
-			if (info.srs.wkt) {
+			if (info.srs && info.srs.wkt) {
 				if (!this.projection) this.projection = info.srs.wkt;
 				else this.fallbackProjection = info.srs.wkt;
 			}


### PR DESCRIPTION
Causing point cloud to not be displayed for certain data sets

I have created a pull request in potree for this fix, but it might take a while to get merged so added it here directly too

Solves this issue: #1039