### PR TITLE
add celery result backend config: retry policy

### DIFF
--- a/worker/celery.py
+++ b/worker/celery.py
@@ -5,6 +5,11 @@ os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'webodm.settings')
 
 app = Celery('tasks')
 app.config_from_object('django.conf:settings', namespace='CELERY')
+app.conf.result_backend_transport_options = {
+    'retry_policy': {
+       'timeout': 5.0
+    }
+}
 
 app.conf.beat_schedule = {
     'update-nodes-info': {


### PR DESCRIPTION
Sometimes  celery redis connection will be abnormal，this is error log:
![image](https://user-images.githubusercontent.com/43440691/132272493-293cd6d8-1170-411f-bd01-eb9bca88b56a.png)
Add this options will fix it.