### PR TITLE
Added support of getting tiles and metadata with geoJSON polygon specified at request param

### DIFF
--- a/app/api/tiler.py
+++ b/app/api/tiler.py
@@ -1,5 +1,4 @@
 import json
-import base64
 import numpy
 import rio_tiler.utils
 from rasterio.enums import ColorInterp


### PR DESCRIPTION
Added support of retrieve metadata for cutline specified as GeoJSON feature or polygon in boundaries ~header~
UPD - migrate this functionality to the request param "boundaries", instead of Header. Also added support of cutting geoJSON tiles using same functionality