### PR TITLE
Added possibility to import file from system.

### DIFF
--- a/app/models/task.py
+++ b/app/models/task.py
@@ -475,6 +475,7 @@ class Task(models.Model):
                     if os.path.isfile(checked_path_to_file):
                         copyfile(checked_path_to_file, zip_path)
                 except SuspiciousFileOperation as e:
+                    logger.error("Error due importing assets from {} for {} in cause of path checking error".format(self.import_url, self))
                     raise NodeServerError(e)
             else:
                 try:


### PR DESCRIPTION
Have an issue during trying to import files from the file system. Instead of using requests file adapter - use native copyfile to unpack filesystem zip with assets.
Format of url for usage is - `file:///this/is/path/to/all.zip`