### PR TITLE
Add vNDVI to formulas.py

### DIFF
--- a/app/api/formulas.py
+++ b/app/api/formulas.py
@@ -20,7 +20,7 @@ algos = {
         'help': _('Enhanced Normalized Difference Vegetation Index is like NDVI, but uses Blue and Green bands instead of only Red to isolate plant health.')
     },
     'vNDVI':{
-        'expr': '0.5268*((R ^ -0.1294) * (G ^ 0.3389) * (B ^ -0.3118))',
+        'expr': '0.5268*((R ** -0.1294) * (G ** 0.3389) * (B ** -0.3118))',
         'help': _('Visible NDVI is an un-normalized index for RGB sensors using constants derived from citrus, grape, and sugarcane crop data.')
     },
     'VARI': {


### PR DESCRIPTION
vNDVI is a new RGB/Visible index derived from a genetic algorithm trained against citrus, grape, and sugarcane crop data.

The index is _not_ normalized, so much care has to be taken when applying it as values will exceed the expected 0-1 range.

Reference paper:  
https://www.sciencedirect.com/science/article/pii/S016816991932383X

Requested by:  
Patrick Cochard

vNDVI (scaled from 0-1 in QGIS):  
![vNDVI_Scaled](https://user-images.githubusercontent.com/19295950/139287346-a195d01d-1b7e-4d9e-9e47-68433fecb4f8.png)

Visible RGB:  
![Visible](https://user-images.githubusercontent.com/19295950/139287410-c17d8025-37d0-4ccc-8900-02c8d5fa8740.png)