### PR TITLE
It can detect NVIDIA driver

### DIFF
--- a/webodm.sh
+++ b/webodm.sh
@@ -171,7 +171,7 @@ detect_gpus(){
 
 	if [ "${platform}" = "Linux" ]; then
 		set +e
-		lspci | grep 'VGA.*NVIDIA'
+		lspci | grep 'NVIDIA'
 		if [ "${?}" -eq 0 ]; then
 			export GPU_NVIDIA=true
 			set -e


### PR DESCRIPTION
`./webodm.sh start --gpu` pulls **opendronemap/nodeodm:gpu.intel** instead of **nvidia**. So, I fix it