### PR TITLE
webodm.sh: remove default_nodes and respect WO_DEFAULT_NODES from .env

### DIFF
--- a/webodm.sh
+++ b/webodm.sh
@@ -18,7 +18,6 @@ if [[ $platform = "Windows" ]]; then
 	export COMPOSE_CONVERT_WINDOWS_PATHS=1
 fi
 
-default_nodes=1
 dev_mode=false
 gpu=false
 
@@ -37,6 +36,7 @@ DEFAULT_MEDIA_DIR="$WO_MEDIA_DIR"
 DEFAULT_SSL="$WO_SSL"
 DEFAULT_SSL_INSECURE_PORT_REDIRECT="$WO_SSL_INSECURE_PORT_REDIRECT"
 DEFAULT_BROKER="$WO_BROKER"
+DEFAULT_NODES="$WO_DEFAULT_NODES"
 
 # Parse args for overrides
 POSITIONAL=()
@@ -103,7 +103,6 @@ case $key in
     shift # past value
     ;;
     --no-default-node)
-    default_nodes=0
     echo "ATTENTION: --no-default-node is deprecated. Use --default-nodes instead."
     export WO_DEFAULT_NODES=0
     shift # past argument
@@ -117,7 +116,6 @@ case $key in
     shift # past argument
     ;;
     --default-nodes)
-    default_nodes="$2"
     export WO_DEFAULT_NODES="$2"
     shift # past argument
     shift # past value
@@ -149,7 +147,7 @@ usage(){
   echo "	--port	<port>	Set the port that WebODM should bind to (default: $DEFAULT_PORT)"
   echo "	--hostname	<hostname>	Set the hostname that WebODM will be accessible from (default: $DEFAULT_HOST)"
   echo "	--media-dir	<path>	Path where processing results will be stored to (default: $DEFAULT_MEDIA_DIR (docker named volume))"
-  echo "	--default-nodes	The amount of default NodeODM nodes attached to WebODM on startup (default: 1)"
+  echo "	--default-nodes	The amount of default NodeODM nodes attached to WebODM on startup (default: $DEFAULT_NODES)"
   echo "	--with-micmac	Create a NodeMICMAC node attached to WebODM on startup. Experimental! (default: disabled)"
   echo "	--ssl	Enable SSL and automatically request and install a certificate from letsencrypt.org. (default: $DEFAULT_SSL)"
   echo "	--ssl-key	<path>	Manually specify a path to the private key file (.pem) to use with nginx to enable SSL (default: None)"
@@ -279,7 +277,7 @@ start(){
 
 	command="docker-compose -f docker-compose.yml"
 
-    if [[ $default_nodes > 0 ]]; then
+    if [[ $WO_DEFAULT_NODES > 0 ]]; then
 		if [ "${GPU_NVIDIA}" = true ]; then
 			command+=" -f docker-compose.nodeodm.gpu.nvidia.yml"
 		elif [ "${GPU_INTEL}" = true ]; then
@@ -341,8 +339,8 @@ start(){
 		command+=" -d"
 	fi
 
-	if [[ $default_nodes > 0 ]]; then
-		command+=" --scale node-odm=$default_nodes"
+	if [[ $WO_DEFAULT_NODES > 0 ]]; then
+		command+=" --scale node-odm=$WO_DEFAULT_NODES"
 	fi
 
 	run "$command"
@@ -461,7 +459,7 @@ elif [[ $1 = "update" ]]; then
 
 	command="docker-compose -f docker-compose.yml"
 
-	if [[ $default_nodes > 0 ]]; then
+	if [[ $WO_DEFAULT_NODES > 0 ]]; then
 		if [ "${GPU_NVIDIA}" = true ]; then
 			command+=" -f docker-compose.nodeodm.gpu.nvidia.yml"
 		elif [ "${GPU_INTEL}" = true ]; then


### PR DESCRIPTION
This fixes #1131 and harmonizes the way WO_DEFAULT_NODES is managed.


Also, I have a warning list from shellcheck for this script that I can fix while I'm at it. This will make the script more robust. For example it looks like the password does not support having spaces in it for now (see #1133 ).


```
Warning	Quote this to prevent word splitting. [SC2046]	3:16
Info	Not following: ./.env was not specified as input (see shellcheck -x). [SC1091]	32:8
Warning	Declare and assign separately to avoid masking return values. [SC2155]	59:12
Warning	Declare and assign separately to avoid masking return values. [SC2155]	68:12
Warning	Declare and assign separately to avoid masking return values. [SC2155]	73:12
Info	Check exit code directly with e.g. 'if mycmd;', not indirectly with $?. [SC2181]	173:8
Info	Check exit code directly with e.g. 'if mycmd;', not indirectly with $?. [SC2181]	180:8
Info	Check exit code directly with e.g. 'if mycmd;', not indirectly with $?. [SC2181]	187:8
Info	Check exit code directly with e.g. 'if mycmd;', not indirectly with $?. [SC2181]	195:8
Warning	Declare and assign separately to avoid masking return values. [SC2155]	207:11
Info	Double quote to prevent globbing and word splitting. [SC2086]	224:7
Info	Use -n instead of ! -z. [SC2236]	228:9
Info	Double quote to prevent globbing and word splitting. [SC2086]	251:7
Info	Double quote to prevent globbing and word splitting. [SC2086]	252:7
Error	> is for string comparisons. Use -gt instead. [SC2071]	280:29
Info	Use -n instead of ! -z. [SC2236]	299:8
Info	Use -n instead of ! -z. [SC2236]	303:8
Info	Use -n instead of ! -z. [SC2236]	311:8
Info	Use -n instead of ! -z. [SC2236]	311:34
Error	> is for string comparisons. Use -gt instead. [SC2071]	342:26
Info	Use -n instead of ! -z. [SC2236]	395:8
Info	Double quote to prevent globbing and word splitting. [SC2086]	402:15
Info	Check exit code directly with e.g. 'if mycmd;', not indirectly with $?. [SC2181]	403:9
Error	> is for string comparisons. Use -gt instead. [SC2071]	462:26
Info	Double quote to prevent globbing and word splitting. [SC2086]	484:16
```