### PR TITLE
Fix for Edit Task Options dialog cut off when opened from plugin

### DIFF
--- a/coreplugins/cloudimport/public/components/ConfigureNewTaskDialog.jsx
+++ b/coreplugins/cloudimport/public/components/ConfigureNewTaskDialog.jsx
@@ -26,7 +26,7 @@ export default class ConfigureNewTaskDialog extends Component {
 
 		const title = "Import from " + (platform !== null ? platform.name : "Platform");
 		return (
-			<Modal className={"new-task"} onHide={onHide} show={true}>
+			<Modal className={"new-task"} onHide={onHide} show={true} dialogClassName="modal-newtask">
 				<Modal.Header closeButton>
 					<Modal.Title>
 						{title}

--- a/coreplugins/cloudimport/public/components/ConfigureNewTaskDialog.scss
+++ b/coreplugins/cloudimport/public/components/ConfigureNewTaskDialog.scss
@@ -5,3 +5,9 @@
 .new-task.modal button i {
 	margin-right: 1em;
 }
+
+/* Fix edit dialog when opened from plugin modal dialog */
+.modal-newtask {
+  min-height: 100%;
+}
+

--- a/coreplugins/dronedb/public/components/ConfigureNewTaskDialog.jsx
+++ b/coreplugins/dronedb/public/components/ConfigureNewTaskDialog.jsx
@@ -23,7 +23,7 @@ export default class ConfigureNewTaskDialog extends Component {
 		} = this.props;
 
 		return (
-			<Modal className={"new-task"} onHide={onHide} show={true}>
+			<Modal className={"new-task"} onHide={onHide} show={true} dialogClassName="modal-newtask">
 				<Modal.Header closeButton>
 					<Modal.Title>
 						Import from DroneDB

--- a/coreplugins/dronedb/public/components/ConfigureNewTaskDialog.scss
+++ b/coreplugins/dronedb/public/components/ConfigureNewTaskDialog.scss
@@ -5,3 +5,9 @@
 .new-task.modal button i {
 	margin-right: 1em;
 }
+
+/* Fix edit dialog when opened from plugin modal dialog */
+.modal-newtask {
+  min-height: 100%;
+}
+


### PR DESCRIPTION
The Edit Task Options dialog is very small if opened from the cloud
import or dronedb import plugin modal dialogs, this css tweak fixes it
to take up the full height of the window.