### PR TITLE
Update EditPresetDialog.jsx: blocklist --ignore-gsd

### DIFF
--- a/app/static/app/js/components/EditPresetDialog.jsx
+++ b/app/static/app/js/components/EditPresetDialog.jsx
@@ -12,7 +12,7 @@ if (!Object.values) {
 }
 
 // Do not apply to WebODM, can cause confusion
-const OPTS_BLACKLIST = ['build-overviews', 'orthophoto-no-tiled', 'orthophoto-compression', 'orthophoto-png', 'orthophoto-kmz', 'pc-copc', 'pc-las', 'pc-ply', 'pc-csv', 'pc-ept', 'cog'];
+const OPTS_BLACKLIST = ['build-overviews', 'ignore-gsd', 'orthophoto-no-tiled', 'orthophoto-compression', 'orthophoto-png', 'orthophoto-kmz', 'pc-copc', 'pc-las', 'pc-ply', 'pc-csv', 'pc-ept', 'cog'];
 
 class EditPresetDialog extends React.Component {
     static defaultProps = {


### PR DESCRIPTION
Let's all say goodbye to our dear, sweet friend ```--ignore-gsd```.

I'd say it will be sorely missed, but I'd be lying:  
![tenor](https://user-images.githubusercontent.com/19295950/172364026-973449e9-8c07-4d3c-af98-4e24612b5533.gif)