### PR TITLE
Updated to check if a public link to use the organization website instead of /

### DIFF
--- a/app/templates/app/base.html
+++ b/app/templates/app/base.html
@@ -93,7 +93,7 @@
                 </button>
                 {% block navbar-top-links %}{% endblock %}
             
-                {% if '/public/task/' in request.path and SETTINGS.organization_website %}
+                {% if request.user.is_anonymous and SETTINGS.organization_website %}
                     <a class="navbar-brand" href="{{ SETTINGS.organization_website }}"><img src="{% settings_image_url 'app_logo_36' %}" alt="{{ SETTINGS.app_name }}" /></a>
                     <a class="navbar-link" href="{{ SETTINGS.organization_website }}"><p class="navbar-text">{{ SETTINGS.app_name }}</p></a>
                 {% else %}

--- a/app/templates/app/base.html
+++ b/app/templates/app/base.html
@@ -93,7 +93,7 @@
                 </button>
                 {% block navbar-top-links %}{% endblock %}
             
-                {% if '/public/task/ in request.path %}
+                {% if '/public/task/' in request.path and SETTINGS.organization_website %}
                     <a class="navbar-brand" href="{{ SETTINGS.organization_website }}"><img src="{% settings_image_url 'app_logo_36' %}" alt="{{ SETTINGS.app_name }}" /></a>
                     <a class="navbar-link" href="{{ SETTINGS.organization_website }}"><p class="navbar-text">{{ SETTINGS.app_name }}</p></a>
                 {% else %}

--- a/app/templates/app/base.html
+++ b/app/templates/app/base.html
@@ -92,8 +92,14 @@
                     <span class="icon-bar"></span>
                 </button>
                 {% block navbar-top-links %}{% endblock %}
-                <a class="navbar-brand" href="/"><img src="{% settings_image_url 'app_logo_36' %}" alt="{{ SETTINGS.app_name }}" /></a>
-                <a class="navbar-link" href="/"><p class="navbar-text">{{ SETTINGS.app_name }}</p></a>
+            
+                {% if '/public/task/ in request.path %}
+                    <a class="navbar-brand" href="{{ SETTINGS.organization_website }}"><img src="{% settings_image_url 'app_logo_36' %}" alt="{{ SETTINGS.app_name }}" /></a>
+                    <a class="navbar-link" href="{{ SETTINGS.organization_website }}"><p class="navbar-text">{{ SETTINGS.app_name }}</p></a>
+                {% else %}
+                    <a class="navbar-brand" href="/"><img src="{% settings_image_url 'app_logo_36' %}" alt="{{ SETTINGS.app_name }}" /></a>
+                    <a class="navbar-link" href="/"><p class="navbar-text">{{ SETTINGS.app_name }}</p></a>
+                {% endif %}
             </div>
 
             {% block navbar-sidebar %}{% endblock %}


### PR DESCRIPTION
If I am using this with a client, I don't want them to be able to click on my logo and go to my public dashboard. Not like they could login, but I feel like it should link to the organization website since they can't do anything in the backend (the point of the public link).

This is my first PR with WebODM. In addition, I am not an expert in Django, so if there's an easier or more "Django-y" way to do this, please let me know. Thank you!