### PR TITLE
Remove auto as a processing node option

### DIFF
--- a/coreplugins/dronedb/public/ShareButton.jsx
+++ b/coreplugins/dronedb/public/ShareButton.jsx
@@ -62,8 +62,6 @@ export default class ShareButton extends React.Component{
                 url: `/api/plugins/dronedb/tasks/${task.id}/status`,
                 contentType: 'application/json'
             }).done(taskInfo => {            
-                console.log(taskInfo);  
-                debugger;  
                 this.setState({taskInfo});
                 if (taskInfo.error && showErrors) this.setState({error: taskInfo.error});
             }).fail(error => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "WebODM",
-  "version": "1.9.15",
+  "version": "1.9.16",
   "description": "User-friendly, extendable application and API for processing aerial imagery.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Originally intended to allow distribution of tasks across multiple nodes, the option to select `Auto` as a processing node option has been confusing a lot of folks with tasks being sent to the wrong node (e.g. Lightning vs a local node). This is mostly superseded as a mechanism by ClusterODM, which can do that more effectively.

I'm keeping the backend option to automatically select "auto" as a processing node, but removing it from the UI to simplify things.﻿
