### PR TITLE
Use pyexiv2 to copy XMP metadata to resized images

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -60,6 +60,7 @@ https://github.com/OpenDroneMap/WebODM/releases/download/v1.9.7/rasterio-1.2.10-
 https://github.com/OpenDroneMap/WebODM/releases/download/v1.9.7/GDAL-3.3.3-cp39-cp39-win_amd64.whl ; sys_platform == "win32"
 Shapely==1.7.0 ; sys_platform == "win32"
 eventlet==0.32.0 ; sys_platform == "win32"
+pyexiv2==2.8.1
 pyopenssl==19.1.0 ; sys_platform == "win32"
 numpy==1.21.1
 drf-yasg==1.20.0


### PR DESCRIPTION
XMP metadata is not copied from the original image to the resized image when resizing images using WebODM. DJI drones store important data in XMP fields including GPS in decimal form, RTK corrections, and speed. This lost of information degrades the final outputs.

An additional dependency, pyexiv2, is needed to read and write XMP tags.