### PR TITLE
Silence django's session data corrupted warnings

### DIFF
--- a/app/boot.py
+++ b/app/boot.py
@@ -34,7 +34,11 @@ def boot():
     logger.info("Booting WebODM {}".format(settings.VERSION))
 
     if settings.DEBUG:
-       logger.warning("Debug mode is ON (for development this is OK)")
+        logger.warning("Debug mode is ON (for development this is OK)")
+
+    # Silence django's "Warning: Session data corrupted" messages
+    session_logger = logging.getLogger("django.security.SuspiciousSession")
+    session_logger.disabled = True
 
     # Make sure our app/media/tmp folder exists
     if not os.path.exists(settings.MEDIA_TMP):


### PR DESCRIPTION
As the title says. This warning has been confusing users for years.

