### PR TITLE
Expose start_date, end_date in Task API

### DIFF
--- a/app/models/task.py
+++ b/app/models/task.py
@@ -409,7 +409,9 @@ class Task(models.Model):
                     'points': points,
                 },
                 'gsd': j.get('odm_processing_statistics', {}).get('average_gsd'),
-                'area': j.get('processing_statistics', {}).get('area')
+                'area': j.get('processing_statistics', {}).get('area'),
+                'start_date': j.get('processing_statistics', {}).get('start_date'),
+                'end_date': j.get('processing_statistics', {}).get('end_date'),
             }
         else:
             return {}


### PR DESCRIPTION
`CURL http://localhost:8000/api/projects/62/tasks/999f2a37-aecc-41a0-964d-9e4b790def21/`

==> 

```
...

],
    "statistics": {
        "pointcloud": {
            "points": 1427792
        },
        "gsd": 1.6182602948297635,
        "area": 7058.434025093657,
        "start_date": "23/06/2016 at 16:31:59",
        "end_date": "23/06/2016 at 16:34:03"
    },
    "uuid": "9a8e3577-91ca-40c8-9b7f-95d0ed8a66da",

...

```


