### PR TITLE
Remove Ultra preset

### DIFF
--- a/app/boot.py
+++ b/app/boot.py
@@ -156,12 +156,6 @@ def add_default_presets():
                                                               {'name': 'pc-quality', 'value': 'high'},
                                                               {'name': 'dem-resolution', 'value': "2.0"},
                                                               {'name': 'orthophoto-resolution', 'value': "2.0"}]})
-        Preset.objects.update_or_create(name='Ultra Quality', system=True,
-                                        defaults={'options': [{'name': 'auto-boundary', 'value': True},
-                                                              {'name': 'dsm', 'value': True},
-                                                              {'name': 'pc-quality', 'value': 'ultra'},
-                                                              {'name': 'dem-resolution', 'value': "2.0"},
-                                                              {'name': 'orthophoto-resolution', 'value': "1.0"}]}) 
         Preset.objects.update_or_create(name='Default', system=True,
                                         defaults={'options': [{'name': 'auto-boundary', 'value': True},
                                                               {'name': 'dsm', 'value': True}]})

--- a/app/tests/test_api_preset.py
+++ b/app/tests/test_api_preset.py
@@ -58,7 +58,7 @@ class TestApiPreset(BootTestCase):
         self.assertTrue(res.status_code == status.HTTP_200_OK)
 
         # Only ours and global presets are available
-        self.assertEqual(len(res.data), 16)
+        self.assertEqual(len(res.data), 15)
         self.assertTrue('My Local Preset' in [preset['name'] for preset in res.data])
         self.assertTrue('High Resolution' in [preset['name'] for preset in res.data])
         self.assertTrue('Global Preset #1' in [preset['name'] for preset in res.data])


### PR DESCRIPTION
The ultra preset confuses a lot of people when it runs out of memory.

https://community.opendronemap.org/t/not-enough-memory-issue/14565

Related discussion: https://github.com/OpenDroneMap/ODM/issues/1584

People selecting the `Ultra` preset are looking for the "best" results, but they don't quite understand the implications of choosing `pc-quality: ultra` (which in itself, is an advanced option which should never be used, unless one knows what they are doing, since it explodes memory usage).