### PR TITLE
Using external source still fills up Docker VHD

### DIFF
--- a/docker-compose.nodeodm.gpu.intel.yml
+++ b/docker-compose.nodeodm.gpu.intel.yml
@@ -13,6 +13,8 @@ services:
     environment:
       - RENDER_GROUP_ID
     image: opendronemap/nodeodm:gpu.intel
+    volumes:
+      - ${WO_MEDIA_DIR}:/var/www/data:z
     devices:
       - "/dev/dri"
     ports:

--- a/docker-compose.nodeodm.gpu.nvidia.yml
+++ b/docker-compose.nodeodm.gpu.nvidia.yml
@@ -11,6 +11,8 @@ services:
       - WO_DEFAULT_NODES
   node-odm:
     image: opendronemap/nodeodm:gpu
+    volumes:
+      - ${WO_MEDIA_DIR}:/var/www/data:z
     ports:
       - "3000"
     restart: unless-stopped


### PR DESCRIPTION
Already discussed in here
https://community.opendronemap.org/t/storage-location-using-external-source-still-fills-up-docker-vhd/4376/14

and

https://community.opendronemap.org/t/utilising-another-harddrive-on-linux-virtual-machine/14780/10

`./webodm.sh start --gpu --media-dir /media/user/the_disk/the_folder`

It was failed because it still fills up Docker VHD

Now, I try to fix it by modifying the `docker-compose.nodeodm.gpu.nvidia.yaml` as suggested by **vantageds** and it will work in this command 

`./webodm.sh start --gpu --media-dir /media/user/the_disk/the_folder`

Hopefully it works, I already tested it