### PR TITLE
Fix dashboard crash when task names are empty

### DIFF
--- a/app/static/app/js/components/TaskList.jsx
+++ b/app/static/app/js/components/TaskList.jsx
@@ -143,7 +143,8 @@ class TaskList extends React.Component {
     return (
       <div className="task-list">
         {this.state.tasks.filter(t => {
-          return t.name.toLocaleLowerCase().indexOf(this.state.filterText.toLocaleLowerCase()) !== -1 &&
+          const name = t.name !== null ? t.name : interpolate(_("Task #%(number)s"), { number: t.id });
+          return name.toLocaleLowerCase().indexOf(this.state.filterText.toLocaleLowerCase()) !== -1 &&
                   this.arrayContainsAll(t.tags, this.state.filterTags);
         }).map(task => (
           <TaskListItem 


### PR DESCRIPTION
Fixes a crash when task names are empty.

@Saijin-Naib I think this is the one you found.
