### PR TITLE
Update task.py

### DIFF
--- a/app/models/task.py
+++ b/app/models/task.py
@@ -1135,4 +1135,4 @@ class Task(models.Model):
                         fd.write(chunk)
                 else:
                     with open(file.temporary_file_path(), 'rb') as f:
-                        copyfileobj(f, fd)
+                        shutil.copyfileobj(f, fd)


### PR DESCRIPTION
`copyfileobj` is not defined. I presume it should be `shutil.copyfileobj`, so it is corrected here.

I have a few hooks in a pre-commit config that help catch these kind of things but maybe this is a result of a merge? 

Anyway, I rebuilt WebODM and confirmed this fixed the upload issue on my side.

Previously this broke uploads (stacktrace below).

```
webapp      | ERROR Internal Server Error: /api/projects/8/tasks/5733e8c1-eecd-4285-8878-cd21a212aad7/upload/
webapp      | Traceback (most recent call last):
webapp      |   File "/usr/local/lib/python3.9/dist-packages/django/core/handlers/exception.py", line 34, in inner
webapp      |     response = get_response(request)
webapp      |   File "/usr/local/lib/python3.9/dist-packages/django/core/handlers/base.py", line 115, in _get_response
webapp      |     response = self.process_exception_by_middleware(e, request)
webapp      |   File "/usr/local/lib/python3.9/dist-packages/django/core/handlers/base.py", line 113, in _get_response
webapp      |     response = wrapped_callback(request, *callback_args, **callback_kwargs)
webapp      |   File "/usr/local/lib/python3.9/dist-packages/django/views/decorators/csrf.py", line 54, in wrapped_view
webapp      |     return view_func(*args, **kwargs)
webapp      |   File "/usr/local/lib/python3.9/dist-packages/rest_framework/viewsets.py", line 125, in view
webapp      |     return self.dispatch(request, *args, **kwargs)
webapp      |   File "/usr/local/lib/python3.9/dist-packages/rest_framework/views.py", line 509, in dispatch
webapp      |     response = self.handle_exception(exc)
webapp      |   File "/usr/local/lib/python3.9/dist-packages/rest_framework/views.py", line 469, in handle_exception
webapp      |     self.raise_uncaught_exception(exc)
webapp      |   File "/usr/local/lib/python3.9/dist-packages/rest_framework/views.py", line 480, in raise_uncaught_exception
webapp      |     raise exc
webapp      |   File "/usr/local/lib/python3.9/dist-packages/rest_framework/views.py", line 506, in dispatch
webapp      |     response = handler(request, *args, **kwargs)
webapp      |   File "/webodm/app/api/tasks.py", line 209, in upload
webapp      |     task.handle_images_upload(files)
webapp      |   File "/webodm/app/models/task.py", line 1138, in handle_images_upload
webapp      |     copyfileobj(f, fd)
webapp      | NameError: name 'copyfileobj' is not defined
```