### PR TITLE
Fixed imports

### DIFF
--- a/coreplugins/dronedb/api_views.py
+++ b/coreplugins/dronedb/api_views.py
@@ -208,10 +208,10 @@ def import_files(task_id, carrier):
     import requests
     from app import models
     from app.plugins import logger
+    from app.security import path_traversal_check
 
     files = carrier['files']
     
-    #headers = CaseInsensitiveDict()
     headers = {}
 
     if carrier['token'] != None:


### PR DESCRIPTION
Fixes https://community.opendronemap.org/t/failure-on-share-to-dronedb-in-webodm/15211/2

This fixes the "DroneDB Import" button that was broken after the last major release of WebODM. I could not reproduce the issue of sharing to DroneDB. It works fine on hub.dronedb.app

