### PR TITLE
Docker-compose: expose ports instead of publishing

### DIFF
--- a/docker-compose.nodemicmac.yml
+++ b/docker-compose.nodemicmac.yml
@@ -12,7 +12,7 @@ services:
   node-micmac-1:
     image: opendronemap/nodemicmac
     container_name: node-micmac-1
-    ports:
+    expose:
       - "3000"
     restart: unless-stopped
     oom_score_adj: 500

--- a/docker-compose.nodeodm.gpu.intel.yml
+++ b/docker-compose.nodeodm.gpu.intel.yml
@@ -15,7 +15,7 @@ services:
     image: opendronemap/nodeodm:gpu.intel
     devices:
       - "/dev/dri"
-    ports:
+    expose:
       - "3000"
     restart: unless-stopped
     oom_score_adj: 500

--- a/docker-compose.nodeodm.gpu.nvidia.yml
+++ b/docker-compose.nodeodm.gpu.nvidia.yml
@@ -11,7 +11,7 @@ services:
       - WO_DEFAULT_NODES
   node-odm:
     image: opendronemap/nodeodm:gpu
-    ports:
+    expose:
       - "3000"
     restart: unless-stopped
     oom_score_adj: 500

--- a/docker-compose.nodeodm.yml
+++ b/docker-compose.nodeodm.yml
@@ -11,7 +11,7 @@ services:
       - WO_DEFAULT_NODES
   node-odm:
     image: opendronemap/nodeodm
-    ports:
+    expose:
       - "3000"
     restart: unless-stopped
     oom_score_adj: 500

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
   db:
     image: opendronemap/webodm_db
     container_name: db
-    ports:
+    expose:
       - "5432"
     volumes:
       - ${WO_DB_DIR}:/var/lib/postgresql/data:Z


### PR DESCRIPTION
With the
```
ports:
  - "12345"
```

syntax Docker publishes the ports under an ephemeral port on the host. Since these ports should presumably only be available to other services, using expose: instead avoids publishing unnecessary services. See #1336