### PR TITLE
Bugfix: Task notification plugin fails to send email notifications in production mode

### DIFF
--- a/coreplugins/tasknotification/config.py
+++ b/coreplugins/tasknotification/config.py
@@ -1,40 +1,39 @@
-import os
-import configparser
-
-script_dir = os.path.dirname(os.path.abspath(__file__))
-
 def load():
-  config = configparser.ConfigParser()
-  config.read(f"{script_dir}/.conf")
-  smtp_configuration = {
-    'smtp_server': config.get('SETTINGS', 'smtp_server', fallback=""),
-    'smtp_port': config.getint('SETTINGS', 'smtp_port', fallback=587),
-    'smtp_username': config.get('SETTINGS', 'smtp_username', fallback=""),
-    'smtp_password': config.get('SETTINGS', 'smtp_password', fallback=""),
-    'smtp_use_tls': config.getboolean('SETTINGS', 'smtp_use_tls', fallback=False),
-    'smtp_from_address': config.get('SETTINGS', 'smtp_from_address', fallback=""),
-    'smtp_to_address': config.get('SETTINGS', 'smtp_to_address', fallback=""),
-    'notification_app_name': config.get('SETTINGS', 'notification_app_name', fallback=""),
-    'notify_task_completed': config.getboolean('SETTINGS', 'notify_task_completed', fallback=False),
-    'notify_task_failed': config.getboolean('SETTINGS', 'notify_task_failed', fallback=False),
-    'notify_task_removed': config.getboolean('SETTINGS', 'notify_task_removed', fallback=False)
-  }
-  return smtp_configuration
+    from app.plugins.functions import get_current_plugin
+    plugin = get_current_plugin(only_active=True)
+    data_store = plugin.get_global_data_store()
 
-def save(data : dict):
-  config = configparser.ConfigParser()
-  config['SETTINGS'] = {
-      'smtp_server': str(data.get('smtp_server')),
-      'smtp_port': str(data.get('smtp_port')),
-      'smtp_username': str(data.get('smtp_username')),
-      'smtp_password': str(data.get('smtp_password')),
-      'smtp_use_tls': str(data.get('smtp_use_tls')),
-      'smtp_from_address': str(data.get('smtp_from_address')),
-      'smtp_to_address': str(data.get('smtp_to_address')),
-      'notification_app_name': str(data.get('notification_app_name')),
-      'notify_task_completed': str(data.get('notify_task_completed')),
-      'notify_task_failed': str(data.get('notify_task_failed')),
-      'notify_task_removed': str(data.get('notify_task_removed'))
-  }
-  with open(f"{script_dir}/.conf", 'w') as configFile:
-      config.write(configFile)
+    smtp_configuration = {
+        'smtp_server': data_store.get_string('smtp_server', default=""),
+        'smtp_port': data_store.get_int('smtp_port', default=587),
+        'smtp_username': data_store.get_string('smtp_username', default=""),
+        'smtp_password': data_store.get_string('smtp_password', default=""),
+        'smtp_use_tls': data_store.get_bool('smtp_use_tls', default=False),
+        'smtp_from_address': data_store.get_string('smtp_from_address', default=""),
+        'smtp_to_address': data_store.get_string('smtp_to_address', default=""),
+        'notification_app_name': data_store.get_string('notification_app_name', default=""),
+        'notify_task_completed': data_store.get_bool('notify_task_completed', default=False),
+        'notify_task_failed': data_store.get_bool('notify_task_failed', default=False),
+        'notify_task_removed': data_store.get_bool('notify_task_removed', default=False)
+    }
+    return smtp_configuration
+
+
+def save(data: dict):
+    from app.plugins.functions import get_current_plugin
+    plugin = get_current_plugin(only_active=True)
+    data_store = plugin.get_global_data_store()
+
+    data_store.set_string('smtp_server', data.get('smtp_server')),
+    data_store.set_int('smtp_port', data.get('smtp_port')),
+    data_store.set_string('smtp_username', data.get('smtp_username')),
+    data_store.set_string('smtp_password', data.get('smtp_password')),
+    data_store.set_bool('smtp_use_tls', data.get('smtp_use_tls')),
+    data_store.set_string('smtp_from_address', data.get('smtp_from_address')),
+    data_store.set_string('smtp_to_address', data.get('smtp_to_address')),
+    data_store.set_string('notification_app_name',
+                          data.get('notification_app_name')),
+    data_store.set_bool('notify_task_completed',
+                        data.get('notify_task_completed')),
+    data_store.set_bool('notify_task_failed', data.get('notify_task_failed')),
+    data_store.set_bool('notify_task_removed', data.get('notify_task_removed'))


### PR DESCRIPTION
##  Description
This PR addresses an issue with the task notification plugin that prevented it from sending email notifications as expected in production mode. Specifically, the plugin was able to send notifications when using the Send test email button on the configuration form of the webapp, but failed to do so when triggered via a signal on a processing node. Although not entirely certain, this behavior may be traced to the plugin's inability to read/write the .conf file when running on processing node instances.

### Solution
To fix the issue, this PR refactors the plugin to use the plugin DataStore instead of the .conf file. This approach ensures that the plugin's configuration is accessible across all instances, allowing it to send email notifications as expected in both dev and production mode.

### Changes
In terms of changes made, the load() and save() functions have been refactored to use the plugin DataStore to retrieve and save the configuration, respectively. This eliminates the need for the .conf file and ensures that the plugin works correctly

### Tests
To confirm the fix, I tested the plugin locally in both dev and production environments and verified that email notifications are sent when tasks finish processing and when tasks fail during processing.