### PR TITLE
Add delete button for read only projects

### DIFF
--- a/app/api/projects.py
+++ b/app/api/projects.py
@@ -197,10 +197,12 @@ class ProjectViewSet(viewsets.ModelViewSet):
         return Response({'success': True}, status=status.HTTP_200_OK)
 
     def destroy(self, request, pk=None):
-        project = get_and_check_project(request, pk, ('delete_project', ))
+        project = get_and_check_project(request, pk, ('view_project', ))
 
         # Owner? Delete the project
         if project.owner == request.user or request.user.is_superuser:
+            get_and_check_project(request, pk, ('delete_project', ))
+
             return super().destroy(self, request, pk=pk)
         else:
             # Do not remove the project, simply remove all user's permissions to the project

--- a/app/static/app/js/components/ProjectListItem.jsx
+++ b/app/static/app/js/components/ProjectListItem.jsx
@@ -400,6 +400,20 @@ class ProjectListItem extends React.Component {
     this.editProjectDialog.show();
   }
 
+  handleHideProject = (deleteWarning, deleteAction) => {
+    return () => {
+      if (window.confirm(deleteWarning)){
+        this.setState({error: "", refreshing: true});
+        deleteAction()
+          .fail(e => {
+            this.setState({error: e.message || (e.responseJSON || {}).detail || e.responseText || _("Could not delete item")});
+          }).always(() => {
+            this.setState({refreshing: false});
+          });
+      }
+    }
+  }
+
   updateProject(project){
     return $.ajax({
         url: `/api/projects/${this.state.data.id}/edit/`,
@@ -681,6 +695,12 @@ class ProjectListItem extends React.Component {
                 [<i key="edit-icon" className='far fa-edit'></i>
                 ,<a key="edit-text" href="javascript:void(0);" onClick={this.handleEditProject}> {_("Edit")}
                 </a>]
+            : ""}
+
+            {!canEdit && !data.owned ? 
+              [<i key="edit-icon" className='far fa-eye-slash'></i>
+              ,<a key="edit-text" href="javascript:void(0);" onClick={this.handleHideProject(deleteWarning, this.handleDelete)}> {_("Delete")}
+              </a>]
             : ""}
 
           </div>

--- a/app/tests/test_api.py
+++ b/app/tests/test_api.py
@@ -253,14 +253,17 @@ class TestApi(BootTestCase):
         for perm in ['delete', 'change', 'add']:
             self.assertFalse(perm in res.data['permissions'])
 
-        # Can't delete a project for which we just have view permissions
-        res = client.delete('/api/projects/{}/'.format(other_temp_project.id))
-        self.assertTrue(res.status_code == status.HTTP_404_NOT_FOUND)
-
-        # Can delete a project for which we have delete permissions
-        assign_perm('delete_project', user, other_temp_project)
+        # Can delete a project for which we just have view permissions
+        # (we will just remove our read permissions without deleting the project)
         res = client.delete('/api/projects/{}/'.format(other_temp_project.id))
         self.assertTrue(res.status_code == status.HTTP_204_NO_CONTENT)
+        
+        # Project still exists
+        self.assertTrue(Project.objects.filter(id=other_temp_project.id).count() == 1)
+
+        # We just can't access it
+        res = client.get('/api/projects/{}/'.format(other_temp_project.id))
+        self.assertTrue(res.status_code == status.HTTP_404_NOT_FOUND)
 
         # A user cannot reassign a task to a
         # project for which he/she has no permissions


### PR DESCRIPTION
Adds a delete button to be shown to users that have read-only 
permissions to a project, since they should be able to remove themselves 
from a project that was shared with them.

<img width="395" alt="image" src="https://github.com/OpenDroneMap/WebODM/assets/1951843/644d9afe-7402-4f4d-9358-4dfeb099dd90">

