### PR TITLE
add pydantic 1.0 in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -55,6 +55,7 @@ webcolors==1.5
 rio-tiler==2.1.2
 rio-color==1.0.4
 rio-cogeo==2.3.1
+pydantic~=1.0
 rasterio==1.2.9 ; sys_platform == 'linux' or sys_platform == 'darwin'
 https://github.com/OpenDroneMap/WebODM/releases/download/v1.9.7/rasterio-1.2.10-cp39-cp39-win_amd64.whl ; sys_platform == "win32"
 https://github.com/OpenDroneMap/WebODM/releases/download/v1.9.7/GDAL-3.3.3-cp39-cp39-win_amd64.whl ; sys_platform == "win32"


### PR DESCRIPTION
When i rebuild webodm, i found a problem about pydantic version.
I resolve this conflict to add pydantic~=1.0 in requirements.txt

```
sudo ./webodm.sh rebuild
docker-compose -f docker-compose.yml -f docker-compose.build.yml build --no-cache

----------------
 Traceback (most recent call last):
   File "/webodm/manage.py", line 22, in <module>
     execute_from_command_line(sys.argv)
   File "/usr/local/lib/python3.9/dist-packages/django/core/management/__init__.py", line 381, in execute_from_command_line
     utility.execute()
   File "/usr/local/lib/python3.9/dist-packages/django/core/management/__init__.py", line 357, in execute
     django.setup()
   File "/usr/local/lib/python3.9/dist-packages/django/__init__.py", line 24, in setup
     apps.populate(settings.INSTALLED_APPS)
   File "/usr/local/lib/python3.9/dist-packages/django/apps/registry.py", line 114, in populate
     app_config.import_models()
   File "/usr/local/lib/python3.9/dist-packages/django/apps/config.py", line 211, in import_models
     self.models_module = import_module(models_module_name)
   File "/usr/lib/python3.9/importlib/__init__.py", line 127, in import_module
     return _bootstrap._gcd_import(name[level:], package, level)
   File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
   File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
   File "<frozen importlib._bootstrap>", line 986, in _find_and_load_unlocked
   File "<frozen importlib._bootstrap>", line 680, in _load_unlocked
   File "<frozen importlib._bootstrap_external>", line 855, in exec_module
   File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
   File "/webodm/app/models/__init__.py", line 2, in <module>
     from .task import Task, validate_task_options, gcp_directory_path
   File "/webodm/app/models/task.py", line 35, in <module>
     from app.cogeo import assure_cogeo
   File "/webodm/app/cogeo.py", line 9, in <module>
     from rio_cogeo.cogeo import cog_validate, cog_translate
   File "/usr/local/lib/python3.9/dist-packages/rio_cogeo/__init__.py", line 3, in <module>
     from rio_cogeo.cogeo import cog_info, cog_translate, cog_validate  # noqa
   File "/usr/local/lib/python3.9/dist-packages/rio_cogeo/cogeo.py", line 13, in <module>
     import morecantile
   File "/usr/local/lib/python3.9/dist-packages/morecantile/__init__.py", line 14, in <module>
     from .defaults import tms  # noqa
   File "/usr/local/lib/python3.9/dist-packages/morecantile/defaults.py", line 11, in <module>
     from .models import TileMatrixSet
   File "/usr/local/lib/python3.9/dist-packages/morecantile/models.py", line 82, in <module>
     class TMSBoundingBox(BaseModel):
   File "/usr/local/lib/python3.9/dist-packages/morecantile/models.py", line 85, in TMSBoundingBox
     type: str = Field("BoundingBoxType", const=True)
   File "/usr/local/lib/python3.9/dist-packages/pydantic/fields.py", line 715, in Field
     raise PydanticUserError('`const` is removed, use `Literal` instead', code='removed-kwargs')
 pydantic.errors.PydanticUserError: `const` is removed, use `Literal` instead
 For further information visit https://errors.pydantic.dev/2.0.2/u/removed-kwargs
```