### PR TITLE
update app/boot.py

### DIFF
--- a/app/boot.py
+++ b/app/boot.py
@@ -105,7 +105,8 @@ def add_default_presets():
     try:
         Preset.objects.update_or_create(name='Multispectral', system=True,
                                         defaults={'options': [{'name': 'auto-boundary', 'value': True},
-                                                              {'name': 'radiometric-calibration', 'value': 'camera'}]})
+                                                              {'name': 'radiometric-calibration', 'value': 'camera'},
+                                                              {'name': 'texturing-skip-global-seam-leveling', 'value': True}]})
         Preset.objects.update_or_create(name='Volume Analysis', system=True,
                                         defaults={'options': [{'name': 'auto-boundary', 'value': True},
                                                               {'name': 'dsm', 'value': True},


### PR DESCRIPTION
Add flag ```--texturing-skip-global-seam-leveling``` since I've seen a number of multispectral datasets processed without this and folks thinking our processing is broken due to getting out of range values. 