### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,35 +335,36 @@ If you wish to run the docker version with auto start/monitoring/stop, etc, as a
 
 This should work on any Linux OS capable of running WebODM, and using a SystemD based service daemon (such as Ubuntu 16.04 server for example).
 
-This has only been tested on Ubuntu 16.04 server.
+This has only been tested on Ubuntu 16.04 server and Red Hat Enterprise Linux 9.
 
 The following pre-requisites are required:
  * Requires odm user
  * Requires docker installed via system (ubuntu: `sudo apt-get install docker.io`)
- * Requires screen to be installed
+ * Requires 'screen' package to be installed
  * Requires odm user member of docker group
- * Required WebODM directory checked out to /webodm
- * Requires that /webodm is recursively owned by odm:odm
- * Requires that a Python 3 environment is used at /webodm/python3-venv
+ * Required WebODM directory checked out/cloned to /opt/WebODM
+ * Requires that /opt/WebODM is recursively owned by odm:odm
+ * Requires that a Python 3 environment is used at /opt/WebODM/python3-venv
 
-If all pre-requisites have been met, and repository is checked out to /opt/WebODM folder, then you can use the following steps to enable and manage the service:
+If all pre-requisites have been met, and repository is checked out/cloned to /opt/WebODM folder, then you can use the following steps to enable and manage the service:
 
 First, to install the service, and enable the services to run at startup from now on:
 ```bash
-sudo systemctl enable /webodm/service/webodm-gunicorn.service
-sudo systemctl enable /webodm/service/webodm-nginx.service
+sudo systemctl enable /opt/WebODM/service/webodm-docker.service
 ```
 
 To manually start/stop the service:
 ```bash
-sudo systemctl stop webodm-gunicorn
-sudo systemctl start webodm-gunicorn
+sudo systemctl stop webodm-docker
+sudo systemctl start webodm-docker
 ```
 
 To manually check service status:
 ```bash
-sudo systemctl status webodm-gunicorn
+sudo systemctl status webodm-docker
 ```
+
+For the adventurous, the repository can be put anyplace you like by editing the ./WebODM/service/webodm-docker.service file before enabling the service the reflect your repository location, and modifying the systemctl enable command to that directiory.
 
 ## Run it natively
 


### PR DESCRIPTION
The instructions for running the the docker image as a Linux service is incorrect (possibly referring to running WebODM natively). These rewritten instructions refers to how I got WebODM Docker running on my RHEL 9 system