### PR TITLE
Fix error shadowing in log when plugin fails to load

### DIFF
--- a/app/plugins/functions.py
+++ b/app/plugins/functions.py
@@ -210,9 +210,12 @@ def get_plugins():
                         module = importlib.import_module("plugins.{}".format(dir))
 
                     plugin = (getattr(module, "Plugin"))()
-                except (ImportError, AttributeError):
-                    module = importlib.import_module("coreplugins.{}".format(dir))
-                    plugin = (getattr(module, "Plugin"))()
+                except (ImportError, AttributeError) as plugin_error:
+                    try:
+                        module = importlib.import_module("coreplugins.{}".format(dir))
+                        plugin = (getattr(module, "Plugin"))()
+                    except (ImportError, AttributeError) as coreplugin_error:
+                        raise coreplugin_error from plugin_error
 
                 # Check version
                 manifest = plugin.get_manifest()
@@ -237,7 +240,7 @@ def get_plugins():
 
                 plugins.append(plugin)
             except Exception as e:
-                logger.warning("Failed to instantiate plugin {}: {}".format(dir, e))
+                logger.warning("Failed to instantiate plugin {}: {}: {}".format(dir, e, e.__cause__))
 
     return plugins
 


### PR DESCRIPTION
Fixes https://github.com/OpenDroneMap/WebODM/issues/1466

I don't think this is the ideal handling of the situation, because all log entries would contain two error messages. But I'm opening the PR for discussion.