### PR TITLE
Add task ID to expanded list item

### DIFF
--- a/app/static/app/js/components/TaskListItem.jsx
+++ b/app/static/app/js/components/TaskListItem.jsx
@@ -579,6 +579,10 @@ class TaskListItem extends React.Component {
                     <td>{Utils.bytesToSize(task.size * 1024 * 1024)}</td>
                   </tr>}
                   <tr>
+                    <td><strong>{_("Task ID:")}</strong></td>
+                    <td>{task.id}</td>
+                  </tr>
+                  <tr>
                       <td><strong>{_("Task Output:")}</strong></td>
                       <td><div className="btn-group btn-toggle"> 
                         <button onClick={this.setView("console")} className={"btn btn-xs " + (this.state.view === "basic" ? "btn-default" : "btn-primary")}>{_("On")}</button>


### PR DESCRIPTION
## Overview

Adds the **Task ID** to the list of properties visible in the expanded list item view of tasks.

![preview-task-id-in-expanded-list-item](https://github.com/OpenDroneMap/WebODM/assets/1619067/2a724000-ea0a-4680-beae-3542a64b0ea5)


## Why

This ID is useful to locate the task directory for inspection.
See https://community.opendronemap.org/t/19285

**Note**: The request made sense to me, and I found this was something I could do quickly to get familiar with the project. So I opened this PR opportunistically, without prior discussion (I didn't find any open issues on the topic, nor closed issues that were obviously related). If this is something that's been considered in the past, or that is otherwise known as not desirable, please feel free to close the PR, no hard feelings! :slightly_smiling_face: 

## Implementation

- The `task.id` was already available in the view.
- Placement:
  - Low in the table, so that the long UUID doesn't impair reading / skimming through
  - Above the **Task Output** to avoid unnecessary movement when the console is toggled

## Testing

I don't think this needs automated testing (it `renders without exploding`!), what do you think?

I tested it manually in "production" with a freshly built Docker image on Linux (screenshot above). 

## Questions

- [ ] This PR contains a new translatable string. Is there something that should be done to make sure it is taken into account for translations?

## Other considerations

I think a good addition to this would be a "Copy to clipboard" button next to the ID (like GitHub puts next to the branch name of this PR for example), but that wasn't straightforward enough to add without discussion.