### PR TITLE
Fix user-facing misspelling, improve a few user-facing strings

### DIFF
--- a/app/static/app/js/components/EditTaskPanel.jsx
+++ b/app/static/app/js/components/EditTaskPanel.jsx
@@ -53,7 +53,7 @@ class EditTaskPanel extends React.Component {
           this.setState({saving: false});
           this.props.onSave(json);
         }).fail(() => {
-          this.setState({saving: false, error: _("Could not update task information. Plese try again.")});
+          this.setState({saving: false, error: _("Could not update task information. Please try again.")});
         });     
     }
 

--- a/app/static/app/js/components/ProcessingNodeOption.jsx
+++ b/app/static/app/js/components/ProcessingNodeOption.jsx
@@ -159,7 +159,7 @@ class ProcessingNodeOption extends React.Component {
     let loadFileControl = "";
     if (this.supportsFileAPI() && this.props.domain === 'json'){
         loadFileControl = ([
-            <button key="btn" type="file" className="btn glyphicon glyphicon-import btn-primary" data-toggle="tooltip" data-placement="left" title={_("Click to import a .JSON file")} onClick={() => this.loadFile()}></button>,
+            <button key="btn" type="file" className="btn glyphicon glyphicon-import btn-primary" data-toggle="tooltip" data-placement="left" title={_("Click to import a JSON file")} onClick={() => this.loadFile()}></button>,
             <input key="file-ctrl" className="file-control" type="file" 
                 accept="text/plain,application/json,application/geo+json,.geojson"
                 onChange={this.handleFileSelect}

--- a/app/static/app/js/components/ProjectListItem.jsx
+++ b/app/static/app/js/components/ProjectListItem.jsx
@@ -225,7 +225,7 @@ class ProjectListItem extends React.Component {
                             totalCount: this.state.upload.totalCount - 1,
                             totalBytes: this.state.upload.totalBytes - file.size
                         });
-                        throw new Error(interpolate(_('Cannot upload %(filename)s, File too Large! Default MaxFileSize is %(maxFileSize)s MB!'), { filename: file.name, maxFileSize: this.dz.options.maxFilesize }));
+                        throw new Error(interpolate(_('Cannot upload %(filename)s, file is too large! Default MaxFileSize is %(maxFileSize)s MB!'), { filename: file.name, maxFileSize: this.dz.options.maxFilesize }));
                     }
                     retry();
                 }else{


### PR DESCRIPTION
## Overview

Fixes three user-facing strings. One of them is an obvious misspelling, the other two are improvements for consistency and overall readability for end-users. (Details in commit message.)

I noticed these as I was browsing the translations in Weblate. I haven't finished my first pass, though. Do you prefer that I open a PR with small batches like this one as I go, or in this case to wait for me to finish reading all the strings? (With the caveat that that may take a little while.)

_As I get more familiar with the precise context in which strings are used, I may have suggestions to improve source strings (e.g. to make them easier to translate, some structures happen to be more complex than other in general), but I don't expect that to be a significant volume._