### PR TITLE
Fix file size check on upload error retry

### DIFF
--- a/app/static/app/js/components/ProjectListItem.jsx
+++ b/app/static/app/js/components/ProjectListItem.jsx
@@ -219,7 +219,7 @@ class ProjectListItem extends React.Component {
 
             try{
                 if (file.status === "error"){
-                    if ((file.size / 1024) > this.dz.options.maxFilesize) {
+                    if ((file.size / 1024 / 1024) > this.dz.options.maxFilesize) {
                         // Delete from upload queue
                         this.setUploadState({
                             totalCount: this.state.upload.totalCount - 1,


### PR DESCRIPTION
Fixes a problem with upload retries when images are larger than ~14MB, causing the retry logic to drop the file upload instead of retrying as it should, due to a wrong unit conversion.

