### PR TITLE
Use export format AUTO for KMZ

### DIFF
--- a/app/raster_utils.py
+++ b/app/raster_utils.py
@@ -51,14 +51,13 @@ def export_raster(input, output, **opts):
         output_raster = output
         jpg_background = 255 # white
 
-        # KMZ is special, we just export it as PNG with EPSG:4326
+        # KMZ is special, we just export it as GeoTIFF
         # and then call GDAL to tile/package it
         kmz = export_format == "kmz"
         if kmz:
-            export_format = "png"
-            epsg = 4326
+            export_format = "gtiff-rgb"
             path_base, _ = os.path.splitext(output)
-            output_raster = path_base + ".png"
+            output_raster = path_base + ".kmz.tif"
 
         if export_format == "jpg":
             driver = "JPEG"
@@ -282,4 +281,4 @@ def export_raster(input, output, **opts):
         if kmz:
             subprocess.check_output(["gdal_translate", "-of", "KMLSUPEROVERLAY", 
                                         "-co", "Name={}".format(name),
-                                        "-co", "FORMAT=PNG", output_raster, output])
+                                        "-co", "FORMAT=AUTO", output_raster, output])


### PR DESCRIPTION
KMZ exports are huge because we use PNG as an output format.

There's an (undocumented?) option for format named "AUTO" which generates tiles in JPEG, unless they are semi-transparent, in which case PNG is used.

This reduces the size of the KMZ, which is helpful, because Google Earth cannot import large files. See https://community.opendronemap.org/t/no-results-empty-kml-file/15907