### PR TITLE
remove line from hard recovery script

### DIFF
--- a/contrib/Hard_Recovery_Guide.md
+++ b/contrib/Hard_Recovery_Guide.md
@@ -79,7 +79,6 @@ def process_task(creating_task):
             creating_task.update_available_assets_field()
             creating_task.potree_scene = {}
             creating_task.running_progress = 1.0
-            creating_task.console_output += gettext("Done!") + "\n"
             creating_task.status = status_codes.COMPLETED
             creating_task.save()
 


### PR DESCRIPTION
the line `creating_task.console_output += gettext("Done!") + "\n"` in the process_task function (hard recovery guide) throws an error when following this process. console_output seems to be undefined in this context. 

Removing the line appears to result in a successful backup.