### PR TITLE
Add GPS location plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN apt-get -qq update && apt-get -o Acquire::Retries=3 -qq install -y --no-inst
     apt-get -o Acquire::Retries=3 -qq update && apt-get -o Acquire::Retries=3 -qq install -y --no-install-recommends python3 python3-pip python3-setuptools python3-wheel git g++ python3-dev python2.7-dev libpq-dev binutils libproj-dev gdal-bin pdal libgdal-dev python3-gdal nginx certbot gettext-base cron postgresql-client-13 gettext tzdata && \
     update-alternatives --install /usr/bin/python python /usr/bin/python2.7 1 && update-alternatives --install /usr/bin/python python /usr/bin/python3.9 2 && \
     # Install pip reqs
-    pip install -U pip && pip install -r requirements.txt "boto3==1.14.14" && \
+    pip install pip==24.0 && pip install -r requirements.txt "boto3==1.14.14" && \
     # Setup cron
     ln -s /webodm/nginx/crontab /var/spool/cron/crontabs/root && chmod 0644 /webodm/nginx/crontab && service cron start && chmod +x /webodm/nginx/letsencrypt-autogen.sh && \
     /webodm/nodeodm/setup.sh && /webodm/nodeodm/cleanup.sh && cd /webodm && \

--- a/coreplugins/gpslocation/__init__.py
+++ b/coreplugins/gpslocation/__init__.py
@@ -1,0 +1,1 @@
+from .plugin import *

--- a/coreplugins/gpslocation/manifest.json
+++ b/coreplugins/gpslocation/manifest.json
@@ -1,0 +1,13 @@
+{
+	"name": "GPS Location",
+	"webodmMinVersion": "0.5.0",
+	"description": "Add a GPS location button to the 2D map view",
+	"version": "1.0.0",
+	"author": "Piero Toffanin",
+	"email": "pt@masseranolabs.com",
+	"repository": "https://github.com/OpenDroneMap/WebODM",
+	"tags": ["gps", "location"],
+	"homepage": "https://github.com/OpenDroneMap/WebODM",
+	"experimental": false,
+	"deprecated": false
+}

--- a/coreplugins/gpslocation/plugin.py
+++ b/coreplugins/gpslocation/plugin.py
@@ -1,0 +1,5 @@
+from app.plugins import PluginBase
+
+class Plugin(PluginBase):
+    def include_js_files(self):
+        return ['main.js']

--- a/coreplugins/gpslocation/public/main.js
+++ b/coreplugins/gpslocation/public/main.js
@@ -1,0 +1,21 @@
+PluginsAPI.Map.willAddControls([
+    	'gpslocation/node_modules/leaflet.locatecontrol/dist/L.Control.Locate.min.js',
+    	'gpslocation/node_modules/leaflet.locatecontrol/dist/L.Control.Locate.min.css'
+	], function(args, _){
+
+    // TODO: how to specify consistent plugin render ordering?
+    // we use a timeout to make sure this button is rendered last
+    // but a better method is warranted
+    setTimeout(function(){
+        L.control.locate({
+            position: 'bottomleft',
+            showPopup: false,
+            locateOptions: {
+                enableHighAccuracy: true
+            },
+            strings: {
+                title: "Show My Location"
+            }
+        }).addTo(args.map);
+    }, 150);
+});

--- a/coreplugins/gpslocation/public/package.json
+++ b/coreplugins/gpslocation/public/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "gpslocation",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "leaflet.locatecontrol": "^0.81.1"
+  }
+}


### PR DESCRIPTION
Adds a button for showing the current GPS location.

Requires WebODM to be run over https, so this is disabled by default.

![image](https://github.com/OpenDroneMap/WebODM/assets/1951843/c2716ddd-39d9-4d12-9a9b-0556b645189d)

