### PR TITLE
Update OpenStreetMap provider in Basemaps.js

### DIFF
--- a/app/static/app/js/classes/Basemaps.js
+++ b/app/static/app/js/classes/Basemaps.js
@@ -20,10 +20,10 @@ export default [
   },
   {
     attribution:
-      '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>',
+      '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>',
     maxZoom: 21,
     minZoom: 0,
-    label: _("OSM Mapnik"),
-    url: "//{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+    label: _("OpenStreetMap"),
+    url: "//tile.openstreetmap.org/{z}/{x}/{y}.png"
   }
 ];


### PR DESCRIPTION
I would like to suggest using the now preferred https://tile.openstreetmap.org URL instead of the current one (`{s}.`), see

https://github.com/openstreetmap/operations/issues/737

Also, changes attribution URL to HTTPS link (use direct links). Furthermore, changes name to simply 'OpenStreetMap'. (use common name)