### PR TITLE
fix: add blank=True to plugindatum's user field

### DIFF
--- a/app/models/plugin_datum.py
+++ b/app/models/plugin_datum.py
@@ -5,7 +5,7 @@ from django.utils.translation import gettext_lazy as _
 
 class PluginDatum(models.Model):
     key = models.CharField(max_length=255, help_text=_("Setting key"), db_index=True, verbose_name=_("Key"))
-    user = models.ForeignKey(settings.AUTH_USER_MODEL, null=True, default=None, on_delete=models.CASCADE, help_text=_("The user this setting belongs to. If NULL, the setting is global."), verbose_name=_("User"))
+    user = models.ForeignKey(settings.AUTH_USER_MODEL, null=True, blank=True, default=None, on_delete=models.CASCADE, help_text=_("The user this setting belongs to. If NULL, the setting is global."), verbose_name=_("User"))
     int_value = models.IntegerField(blank=True, null=True, default=None, verbose_name=_("Integer value"))
     float_value = models.FloatField(blank=True, null=True, default=None, verbose_name=_("Float value"))
     bool_value = models.NullBooleanField(blank=True, null=True, default=None, verbose_name=_("Bool value"))


### PR DESCRIPTION
In order to allow for global, plugin-wide settings, the PluginDatum's user field is nullable. However, the field doesn't come with the `blank=True` keyword argument. This makes it impossible to modify a global plugin setting from the admin panel, because the form will require the corresponding form field to contain a value.

This PR fixes this by adding `blank=True` to the `user` field, enabling administrators to change PluginDatum objects keeping the `user` value to null.