### PR TITLE
Use StreamingHttpResponse when downloading zip streams

### DIFF
--- a/app/tests/test_api_task_import.py
+++ b/app/tests/test_api_task_import.py
@@ -74,7 +74,7 @@ class TestApiTask(BootTransactionTestCase):
             assets_path = os.path.join(settings.MEDIA_TMP, "all.zip")
 
             with open(assets_path, 'wb') as f:
-                f.write(res.content)
+                f.write(b''.join(res.streaming_content))
 
             remove_perm('change_project', user, project)
 
@@ -272,7 +272,7 @@ class TestApiTask(BootTransactionTestCase):
             assets_path = os.path.join(settings.MEDIA_TMP, "backup.zip")
 
             with open(assets_path, 'wb') as f:
-                f.write(res.content)
+                f.write(b''.join(res.streaming_content))
 
             assets_file = open(assets_path, 'rb')
 

--- a/app/vendor/zipfly.py
+++ b/app/vendor/zipfly.py
@@ -46,7 +46,6 @@ class ZipflyStream(io.RawIOBase):
     def size(self):
         return self._size
 
-
 class ZipFly:
 
     def __init__(self,
@@ -280,13 +279,17 @@ class ZipFly:
 class ZipStream:
     def __init__(self, paths):
         self.paths = paths
-        self.generator = None
+        self._generator = None
 
     def lazy_load(self, chunksize):
-        if self.generator is None:
+        if self._generator is None:
             zfly = ZipFly(paths=self.paths, mode='w', chunksize=chunksize)
-            self.generator = zfly.generator()
+            self._generator = zfly.generator()
 
     def read(self, count):
         self.lazy_load(count)
-        return next(self.generator)
+        return next(self._generator)
+
+    def generator(self):
+        self.lazy_load(0x8000)
+        return self._generator

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "WebODM",
-  "version": "2.5.3",
+  "version": "2.5.4",
   "description": "User-friendly, extendable application and API for processing aerial imagery.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This fixes a big issue with memory usage when downloading large .zip assets (e.g. a task's backup).

Now downloads start immediately (no delay) and use very little memory.

