### PR TITLE
Create BIGTIFF output during export if needed

### DIFF
--- a/app/admin.py
+++ b/app/admin.py
@@ -268,8 +268,18 @@ class ProfileInline(admin.StackedInline):
     model = Profile
     can_delete = False
 
+    # Hide "quota" profile field when adding (show during editing)
+    def get_fields(self, request, obj=None):
+        if obj is None:
+            fields = list(super().get_fields(request, obj))
+            fields.remove('quota')
+            return fields
+        else:
+            return super().get_fields(request, obj)
+
 class UserAdmin(BaseUserAdmin):
     inlines = [ProfileInline]
+
 
 # Re-register UserAdmin
 admin.site.unregister(User)

--- a/app/classes/console.py
+++ b/app/classes/console.py
@@ -51,3 +51,14 @@ class Console:
                     f.write(text)
             except IOError:
                 logger.warn("Cannot reset console file: %s" % self.file)
+
+    def delink(self):
+        try:
+            if os.path.isfile(self.file) and os.stat(self.file).st_nlink > 1:
+                with open(self.file, "r", encoding="utf-8") as f:
+                    text = f.read()
+                os.unlink(self.file)
+                with open(self.file, "w", encoding="utf-8") as f:
+                    f.write(text)
+        except OSError:
+            logger.warn("Cannot delink console file: %s" % self.file)

--- a/app/models/task.py
+++ b/app/models/task.py
@@ -438,6 +438,9 @@ class Task(models.Model):
                     try:
                         # Try to use hard links first
                         shutil.copytree(self.task_path(), task.task_path(), copy_function=os.link)
+
+                        # Make sure the console output is not linked to the original task
+                        task.console.delink()
                     except Exception as e:
                         logger.warning("Cannot duplicate task using hard links, will use normal copy instead: {}".format(str(e)))
                         shutil.copytree(self.task_path(), task.task_path())

--- a/app/raster_utils.py
+++ b/app/raster_utils.py
@@ -72,12 +72,14 @@ def export_raster(input, output, **opts):
         elif export_format == "gtiff-rgb":
             compress = "JPEG"
             profile.update(jpeg_quality=90)
+            profile.update(BIGTIFF='IF_SAFER')
             band_count = 4
             rgb = True
         else:
             compress = "DEFLATE"
+            profile.update(BIGTIFF='IF_SAFER')
             band_count = src.count
-        
+
         if compress is not None:
             profile.update(compress=compress)
             profile.update(predictor=2 if compress == "DEFLATE" else 1)
@@ -163,7 +165,8 @@ def export_raster(input, output, **opts):
                         src_crs=src.crs,
                         dst_transform=transform,
                         dst_crs=dst_crs,
-                        resampling=Resampling.nearest)
+                        resampling=Resampling.nearest,
+                        num_threads=4)
 
         else:
             # No reprojection needed


### PR DESCRIPTION
Currently larger TIFF outputs will fail to export with a `Chunk and warp failed` error message when the file exceeds 4GB.

