### PR TITLE
Links for 3D meshes support

### DIFF
--- a/app/views/public.py
+++ b/app/views/public.py
@@ -53,7 +53,8 @@ def handle_model_display(request, template, task_pk=None):
                 'task': json.dumps(task.get_model_display_params()),
                 'public': 'true',
                 'public-edit': str(task.public_edit).lower(),
-                'share-buttons': 'false' if settings.DESKTOP_MODE else 'true'
+                'share-buttons': 'false' if settings.DESKTOP_MODE else 'true',
+                'model-type': request.GET.get('t', 'cloud'),
             }.items()
         })
 


### PR DESCRIPTION
Adds support to share links for displaying 3D textured models instead of the default point cloud.

This works by passing a `?t=mesh` query argument to the share URL, similarly to map view.

