### PR TITLE
Handle import chunk retries

### DIFF
--- a/app/api/tasks.py
+++ b/app/api/tasks.py
@@ -471,6 +471,7 @@ class TaskAssetsImport(APIView):
                 os.unlink(tmp_upload_file)
             
             with open(tmp_upload_file, 'ab') as fd:
+                fd.truncate(byte_offset)
                 fd.seek(byte_offset)
                 if isinstance(files[0], InMemoryUploadedFile):
                     for chunk in files[0].chunks():

--- a/app/static/app/js/components/ImportTaskPanel.jsx
+++ b/app/static/app/js/components/ImportTaskPanel.jsx
@@ -53,7 +53,9 @@ class ImportTaskPanel extends React.Component {
           clickable: this.uploadButton,
           timeout: 2147483647,
           chunking: true,
-          chunkSize: 16000000, // 16MB
+          chunkSize: 16000000, // 16MB,
+          retryChunks: true,
+          retryChunksLimit: 20,
           headers: {
             [csrf.header]: csrf.token
           }
@@ -91,7 +93,7 @@ class ImportTaskPanel extends React.Component {
             }catch(e){
               this.setState({error: interpolate(_('Invalid response from server: %(error)s'), { error: e.message})});
             }
-          }else if (this.state.uploading){
+          }else{
             this.setState({uploading: false, error: _("An error occured while uploading the file. Please try again.")});
           }
         });


### PR DESCRIPTION
Adds the ability to retry chunk import uploads, which is important in environments where network connectivity is intermittent. 