### PR TITLE
Reduce memory usage in DEMs rasterization

### DIFF
--- a/app/api/hillshade.py
+++ b/app/api/hillshade.py
@@ -79,15 +79,15 @@ class LightSource:
 
         # compute the normal vectors from the partial derivatives
         e_dy, e_dx = np.gradient(vert_exag * elevation, dy, dx)
-
-        # .view is to keep subclasses
-        normal = np.empty(elevation.shape + (3,)).view(type(elevation))
+        
+        normal = np.empty(elevation.shape + (3,), dtype=np.float32)
         normal[..., 0] = -e_dx
         normal[..., 1] = -e_dy
         normal[..., 2] = 1
-        normal /= _vector_magnitude(normal)
+        np.divide(normal, _vector_magnitude(normal), out=normal)
 
-        return self.shade_normals(normal, fraction).astype(np.float32)
+        return self.shade_normals(normal, fraction)
+
 
     def shade_normals(self, normals, fraction=1.):
         """
@@ -112,7 +112,7 @@ class LightSource:
             completely in shadow and 1 is completely illuminated.
         """
 
-        intensity = normals.dot(self.direction)
+        intensity = normals.dot(self.direction.astype(np.float32))
 
         # Apply contrast stretch
         imin, imax = intensity.min(), intensity.max()

--- a/app/api/hillshade.py
+++ b/app/api/hillshade.py
@@ -87,7 +87,7 @@ class LightSource:
         normal[..., 2] = 1
         normal /= _vector_magnitude(normal)
 
-        return self.shade_normals(normal, fraction)
+        return self.shade_normals(normal, fraction).astype(np.float32)
 
     def shade_normals(self, normals, fraction=1.):
         """

--- a/app/api/hsvblend.py
+++ b/app/api/hsvblend.py
@@ -80,6 +80,7 @@ def hsv_to_rgb( h, s, v ):
 
 def hsv_blend(rgb, intensity):
     h, s = rgb_to_hs(rgb[0], rgb[1], rgb[2])
+
     #replace v with hillshade
     #convert back to RGB
     return hsv_to_rgb(h, s, intensity)

--- a/app/api/hsvblend.py
+++ b/app/api/hsvblend.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-# Originally based on work by Frank and Evan
+# Originally based on work by Frank and Even
 # Modified by Piero Toffanin for speed and lower memory usage
 # The code here is re-licensed under AGPLv3, but is based on MIT
 

--- a/app/api/hsvblend.py
+++ b/app/api/hsvblend.py
@@ -1,5 +1,9 @@
 import numpy as np
 
+# Originally based on work by Frank and Evan
+# Modified by Piero Toffanin for speed and lower memory usage
+# The code here is re-licensed under AGPLv3, but is based on MIT
+
 #******************************************************************************
 #  Copyright (c) 2009, Frank Warmerdam
 #  Copyright (c) 2010, Even Rouault <even dot rouault at mines-paris dot org>
@@ -25,44 +29,34 @@ import numpy as np
 
 
 # =============================================================================
-# rgb_to_hsv()
+# rgb_to_hs()
 #
 # rgb comes in as [r,g,b] with values in the range [0,255].  The returned
-# hsv values will be with hue and saturation in the range [0,1] and value
-# in the range [0,255]
+# hsv values will be with hue and saturation in the range [0,1]
 #
-def rgb_to_hsv( r,g,b ):
 
+def rgb_to_hs( r, g, b ):
+    
     maxc = np.maximum(r,np.maximum(g,b))
     minc = np.minimum(r,np.minimum(g,b))
 
-    v = maxc
-
-    minc_eq_maxc = np.equal(minc,maxc)
-
     # compute the difference, but reset zeros to ones to avoid divide by zeros later.
-    ones = np.ones((r.shape[0],r.shape[1]))
-    maxc_minus_minc = np.choose( minc_eq_maxc, (maxc-minc,ones) )
+    ones = np.ones((r.shape[0],r.shape[1]), dtype=np.uint8)
+    maxc_minus_minc = np.choose( minc==maxc, (maxc-minc,ones) )
 
-    s = (maxc-minc) / np.maximum(ones,maxc)
-    rc = (maxc-r) / maxc_minus_minc
-    gc = (maxc-g) / maxc_minus_minc
-    bc = (maxc-b) / maxc_minus_minc
+    s = np.divide((maxc-minc), np.maximum(ones,maxc), dtype=np.float32)
+    rc = np.divide((maxc-r), maxc_minus_minc, dtype=np.float32)
+    gc = np.divide((maxc-g), maxc_minus_minc, dtype=np.float32)
+    bc = np.divide((maxc-b), maxc_minus_minc, dtype=np.float32)
 
-    maxc_is_r = np.equal(maxc,r)
-    maxc_is_g = np.equal(maxc,g)
-    maxc_is_b = np.equal(maxc,b)
+    h = np.zeros((r.shape[0],r.shape[1]), dtype=np.float32)
+    np.choose( maxc==b, (h,4.0+gc-rc), out=h)
+    np.choose( maxc==g, (h,2.0+rc-bc), out=h)
+    np.choose( maxc==r, (h,bc-gc), out=h)
 
-    h = np.zeros((r.shape[0],r.shape[1]))
-    h = np.choose( maxc_is_b, (h,4.0+gc-rc) )
-    h = np.choose( maxc_is_g, (h,2.0+rc-bc) )
-    h = np.choose( maxc_is_r, (h,bc-gc) )
+    np.mod(h/6.0,1.0,out=h)
 
-    h = np.mod(h/6.0,1.0)
-
-    hsv = np.asarray([h,s,v])
-
-    return hsv
+    return h, s
 
 # =============================================================================
 # hsv_to_rgb()
@@ -70,13 +64,7 @@ def rgb_to_hsv( r,g,b ):
 # hsv comes in as [h,s,v] with hue and saturation in the range [0,1],
 # but value in the range [0,255].
 
-def hsv_to_rgb( hsv ):
-
-    h = hsv[0]
-    s = hsv[1]
-    v = hsv[2]
-
-    #if s == 0.0: return v, v, v
+def hsv_to_rgb( h, s, v ):
     i = (h*6.0).astype(int)
     f = (h*6.0) - i
     p = v*(1.0 - s)
@@ -87,16 +75,11 @@ def hsv_to_rgb( hsv ):
     g = i.choose( t, v, v, q, p, p )
     b = i.choose( p, p, t, v, v, q )
 
-    rgb = np.asarray([r,g,b]).astype(np.uint8)
-
-    return rgb
+    return np.asarray([r,g,b]).astype(np.uint8)
 
 
 def hsv_blend(rgb, intensity):
-    hsv = rgb_to_hsv(rgb[0], rgb[1], rgb[2])
-
+    h, s = rgb_to_hs(rgb[0], rgb[1], rgb[2])
     #replace v with hillshade
-    hsv_adjusted = np.asarray( [hsv[0], hsv[1], intensity] )
-
     #convert back to RGB
-    return hsv_to_rgb( hsv_adjusted )
+    return hsv_to_rgb(h, s, intensity)


### PR DESCRIPTION
Significantly reduces the memory required to export/render hillshaded DEMs (tiles, exported outputs) by reducing the amount of memory required and switching certain computations to float32. 