### PR TITLE
More consistent hillshading across zoom levels

### DIFF
--- a/app/api/hillshade.py
+++ b/app/api/hillshade.py
@@ -71,12 +71,6 @@ class LightSource:
             A 2d array of illumination values between 0-1, where 0 is
             completely in shadow and 1 is completely illuminated.
         """
-
-        # Because most image and raster GIS data has the first row in the array
-        # as the "top" of the image, dy is implicitly negative.  This is
-        # consistent to what `imshow` assumes, as well.
-        dy = -dy
-
         # compute the normal vectors from the partial derivatives
         e_dy, e_dx = np.gradient(vert_exag * elevation, dy, dx)
         

--- a/app/api/hillshade.py
+++ b/app/api/hillshade.py
@@ -109,19 +109,19 @@ class LightSource:
         intensity = normals.dot(self.direction.astype(np.float32))
 
         # Apply contrast stretch
-        imin, imax = intensity.min(), intensity.max()
+        # imin, imax = np.nanmin(intensity), np.nanmax(intensity)
         intensity *= fraction
 
         # Rescale to 0-1, keeping range before contrast stretch
         # If constant slope, keep relative scaling (i.e. flat should be 0.5,
         # fully occluded 0, etc.)
-        if (imax - imin) > 1e-6:
+        # if (imax - imin) > 1e-6:
             # Strictly speaking, this is incorrect. Negative values should be
             # clipped to 0 because they're fully occluded. However, rescaling
             # in this manner is consistent with the previous implementation and
             # visually appears better than a "hard" clip.
-            intensity -= imin
-            intensity /= (imax - imin)
+            # intensity -= imin
+            # intensity /= (imax - imin)
         intensity = np.clip(intensity, 0, 1)
 
         return intensity

--- a/app/api/tiler.py
+++ b/app/api/tiler.py
@@ -463,7 +463,7 @@ class Tiles(TaskNestedView):
                 if tile.data.shape[0] != 1:
                     raise exceptions.ValidationError(
                         _("Cannot compute hillshade of non-elevation raster (multiple bands found)"))
-                delta_scale = (maxzoom + ZOOM_EXTRA_LEVELS + 1 - z) * 4
+                delta_scale = (maxzoom + ZOOM_EXTRA_LEVELS + 1 - z) ** 2
                 dx = src.dataset.meta["transform"][0] * delta_scale
                 dy = -src.dataset.meta["transform"][4] * delta_scale
                 ls = LightSource(azdeg=315, altdeg=45)

--- a/app/api/tiler.py
+++ b/app/api/tiler.py
@@ -465,7 +465,7 @@ class Tiles(TaskNestedView):
                         _("Cannot compute hillshade of non-elevation raster (multiple bands found)"))
                 delta_scale = (maxzoom + ZOOM_EXTRA_LEVELS + 1 - z) ** 2
                 dx = src.dataset.meta["transform"][0] * delta_scale
-                dy = -src.dataset.meta["transform"][4] * delta_scale
+                dy = src.dataset.meta["transform"][4] * delta_scale
                 ls = LightSource(azdeg=315, altdeg=45)
                 
                 # Remove elevation data from edge buffer tiles

--- a/app/raster_utils.py
+++ b/app/raster_utils.py
@@ -235,7 +235,7 @@ def export_raster(input, output, **opts):
                 if hillshade is not None and hillshade > 0:
                     delta_scale = ZOOM_EXTRA_LEVELS ** 2
                     dx = src.meta["transform"][0] * delta_scale
-                    dy = -src.meta["transform"][4] * delta_scale
+                    dy = src.meta["transform"][4] * delta_scale
                     ls = LightSource(azdeg=315, altdeg=45)
                     intensity = ls.hillshade(arr[0], dx=dx, dy=dy, vert_exag=hillshade)
                     intensity = intensity * 255.0

--- a/app/raster_utils.py
+++ b/app/raster_utils.py
@@ -233,7 +233,7 @@ def export_raster(input, output, **opts):
 
                 intensity = None
                 if hillshade is not None and hillshade > 0:
-                    delta_scale = (ZOOM_EXTRA_LEVELS + 1) * 4
+                    delta_scale = ZOOM_EXTRA_LEVELS ** 2
                     dx = src.meta["transform"][0] * delta_scale
                     dy = -src.meta["transform"][4] * delta_scale
                     ls = LightSource(azdeg=315, altdeg=45)


### PR DESCRIPTION
I realized that the dynamic tiler applies hillshading inconsistently, e.g. at higher zoom levels the shading appears "lighter" than lower zoom levels. This can be noticed when zooming in/out. This is because the formula for `delta_scale` was linear, instead of quadratic, which is incorrect.

This would also lead to inconsistencies when exporting hillshaded DEMs, where the hillshading looked particularly "light" instead of looking like on-screen.

