### PR TITLE
Update gunicorn to 19.8.0 fixing #1586

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ djangorestframework-guardian==0.3.0
 drf-nested-routers==0.11.1
 funcsigs==1.0.2
 futures==3.1.1
-gunicorn==19.7.1
+gunicorn==19.8.0
 itypes==1.1.0
 kombu==4.6.7
 Markdown==3.3.4


### PR DESCRIPTION
As the title says, this fixes issue #1586. I tested this change by building a docker image (using `docker-compose.build.yml`) containing the change and then basically starting the image with the `webodm.sh` script. The container actually contained the correct `sock.py` file (which contains the problematic code causing the issue in the old version) and starts without problems. I also tried the web-interface and used WebODM on a set of images. Everything worked great.