### PR TITLE
Add 172.16 /12 as Private IP Range

### DIFF
--- a/app/static/app/js/components/SharePopup.jsx
+++ b/app/static/app/js/components/SharePopup.jsx
@@ -122,11 +122,12 @@ class SharePopup extends React.Component{
   showLocalLinkAlert = () => {
     const link = new URL(Utils.absoluteUrl("/")).hostname;
     return !this.state.localLinkAlertDismissed && 
-                      (link.indexOf("localhost") === 0 || 
-                       link.indexOf("192.168.") === 0 || 
-                       link.indexOf("0.0.0.0") === 0 || 
+                      (link.indexOf("0.0.0.0") === 0 || 
+                       link.indexOf("localhost") === 0 || 
                        link.indexOf("127.0.0.1") === 0 || 
                        link.indexOf("10.") === 0 || 
+                       (link.indexOf("172.") === 0 && parseInt(link.split(".")[1], 10) >= 16 && parseInt(link.split(".")[1], 10) <= 31) || 
+                       link.indexOf("192.168.") === 0 || 
                        link.indexOf("::1") === 0);
   }
 


### PR DESCRIPTION
Adds a check for the 172.16 /12 private address range so all IPv4 private IP ranges are now checked.

Also re-orders the checks so that they are grouped a bit more logically (IPv4 default route, then localhost addresses, then private IP ranges, then IPv6 localhost).

cf [PR#1623](https://github.com/OpenDroneMap/WebODM/pull/1623)