### PR TITLE
Respect processing nodes visibility permissions

### DIFF
--- a/app/models/task.py
+++ b/app/models/task.py
@@ -656,7 +656,7 @@ class Task(models.Model):
                 # No processing node assigned and need to auto assign
                 if self.processing_node is None:
                     # Assign first online node with lowest queue count
-                    self.processing_node = ProcessingNode.find_best_available_node()
+                    self.processing_node = ProcessingNode.find_best_available_node(self.project.owner)
                     if self.processing_node:
                         self.processing_node.queue_count += 1 # Doesn't have to be accurate, it will get overridden later
                         self.processing_node.save()

--- a/app/tests/test_api_export.py
+++ b/app/tests/test_api_export.py
@@ -13,6 +13,7 @@ from app.plugins.signals import task_completed
 from app.tests.classes import BootTransactionTestCase
 from app.models import Project, Task
 from nodeodm.models import ProcessingNode
+from guardian.shortcuts import assign_perm
 from nodeodm import status_codes
 
 import worker
@@ -58,7 +59,9 @@ class TestApiTask(BootTransactionTestCase):
 
             # Create processing node
             pnode = ProcessingNode.objects.create(hostname="localhost", port=11223)
-
+            assign_perm('view_processingnode', user, pnode)
+            assign_perm('view_processingnode', other_user, pnode)
+            
             # task creation via file upload
             image1 = open("app/fixtures/tiny_drone_image.jpg", 'rb')
             image2 = open("app/fixtures/tiny_drone_image_2.jpg", 'rb')

--- a/app/tests/test_api_task.py
+++ b/app/tests/test_api_task.py
@@ -29,6 +29,7 @@ from app.plugins.signals import task_completed, task_removed, task_removing
 from app.tests.classes import BootTransactionTestCase
 from nodeodm import status_codes
 from nodeodm.models import ProcessingNode
+from guardian.shortcuts import assign_perm
 from app.testwatch import testWatch
 from .utils import start_processing_node, clear_test_media_root, catch_signal
 
@@ -71,7 +72,9 @@ class TestApiTask(BootTransactionTestCase):
 
             # Create processing node
             pnode = ProcessingNode.objects.create(hostname="localhost", port=11223)
-
+            assign_perm('view_processingnode', user, pnode)
+            assign_perm('view_processingnode', other_user, pnode)
+            
             # Verify that it's working
             self.assertTrue(pnode.api_version is not None)
 
@@ -1094,6 +1097,8 @@ class TestApiTask(BootTransactionTestCase):
         task = Task.objects.create(project=project, name="Test")
         pnode = ProcessingNode.objects.create(hostname="invalid-host", port=11223)
         another_pnode = ProcessingNode.objects.create(hostname="invalid-host-2", port=11223)
+        assign_perm('view_processingnode', project.owner, pnode)
+        assign_perm('view_processingnode', project.owner, another_pnode)
 
         # By default
         self.assertTrue(task.auto_processing_node)
@@ -1178,6 +1183,8 @@ class TestApiTask(BootTransactionTestCase):
 
         # Bring a processing node online
         pnode = ProcessingNode.objects.create(hostname="invalid-host", port=11223)
+        assign_perm('view_processingnode', user, pnode)
+
         pnode.last_refreshed = timezone.now()
         pnode.save()
         self.assertTrue(pnode.is_online())
@@ -1202,7 +1209,8 @@ class TestApiTask(BootTransactionTestCase):
             )
 
             pnode = ProcessingNode.objects.create(hostname="localhost", port=11223)
-
+            assign_perm('view_processingnode', user, pnode)
+            
             # task creation via chunked upload
             image1 = open("app/fixtures/tiny_drone_image.jpg", 'rb')
             image2 = open("app/fixtures/tiny_drone_image_2.jpg", 'rb')

--- a/app/tests/test_api_task_import.py
+++ b/app/tests/test_api_task_import.py
@@ -40,6 +40,7 @@ class TestApiTask(BootTransactionTestCase):
 
             # Create processing node
             pnode = ProcessingNode.objects.create(hostname="localhost", port=11223)
+            assign_perm('view_processingnode', user, pnode)
             client.login(username="testuser", password="test1234")
 
             # Create task
@@ -233,6 +234,8 @@ class TestApiTask(BootTransactionTestCase):
 
             # Create processing node
             pnode = ProcessingNode.objects.create(hostname="localhost", port=11223)
+            assign_perm('view_processingnode', user, pnode)
+
             client.login(username="testuser", password="test1234")
 
             # Create task

--- a/nodeodm/models.py
+++ b/nodeodm/models.py
@@ -53,9 +53,11 @@ class ProcessingNode(models.Model):
             nodes = get_objects_for_user(user, 'view_processingnode', ProcessingNode, accept_global_perms=False)
         else:
             nodes = ProcessingNode.objects.all()
+
+        if not settings.NODE_OPTIMISTIC_MODE:
+            nodes = nodes.filter(last_refreshed__gte=timezone.now() - timedelta(minutes=settings.NODE_OFFLINE_MINUTES))
         
-        return nodes.filter(last_refreshed__gte=timezone.now() - timedelta(minutes=settings.NODE_OFFLINE_MINUTES)) \
-                                     .order_by('queue_count').first()
+        return nodes.order_by('queue_count').first()
 
     def is_online(self):
         if settings.NODE_OPTIMISTIC_MODE:


### PR DESCRIPTION
Auto-assigning a processing node should respect guardian's visibility permissions.