### PR TITLE
Add IPV6 Support

### DIFF
--- a/docker-compose.ipv6.yml
+++ b/docker-compose.ipv6.yml
@@ -1,0 +1,9 @@
+version: '2.2'
+networks:
+  default:
+    enable_ipv6: true
+    ipam:
+      driver: default
+      config:
+        - subnet: "172.21.0.0/16"
+        - subnet: "fdec:cc68:5178::/64"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,11 +56,3 @@ services:
       - WO_SECRET_KEY
     restart: unless-stopped
     oom_score_adj: 250
-networks:
-  default:
-    enable_ipv6: true
-    ipam:
-      driver: default
-      config:
-        - subnet: "172.21.0.0/16"
-        - subnet: "fdec:cc68:5178::/64"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,3 +56,11 @@ services:
       - WO_SECRET_KEY
     restart: unless-stopped
     oom_score_adj: 250
+networks:
+  default:
+    enable_ipv6: true
+    ipam:
+      driver: default
+      config:
+        - subnet: "172.21.0.0/16"
+        - subnet: "fdec:cc68:5178::/64"

--- a/nginx/nginx-ssl.conf.template
+++ b/nginx/nginx-ssl.conf.template
@@ -36,6 +36,7 @@ http {
 
   server {
     listen 8000 deferred;
+    listen [::]:8000 deferred;
     client_max_body_size 0;
 
     server_name $WO_HOST;

--- a/nginx/nginx.conf.template
+++ b/nginx/nginx.conf.template
@@ -29,6 +29,7 @@ http {
 
   server {
     listen 8000 deferred;
+    listen [::]:8000 deferred;
     client_max_body_size 0;
 
     server_name $WO_HOST;

--- a/webodm.sh
+++ b/webodm.sh
@@ -148,6 +148,10 @@ case $key in
     shift # past argument
     shift # past value
     ;;
+    --ipv6)
+    ipv6=true
+    shift # past argument
+    ;;
     *)    # unknown option
     POSITIONAL+=("$1") # save it in an array for later
     shift # past argument
@@ -192,6 +196,7 @@ usage(){
   echo "	--settings	Path to a settings.py file to enable modifications of system settings (default: None)"
   echo "	--worker-memory	Maximum amount of memory allocated for the worker process (default: unlimited)"
   echo "	--worker-cpus	Maximum number of CPUs allocated for the worker process (default: all)"
+  echo "	--ipv6	Enable IPV6"
   
   exit
 }
@@ -457,6 +462,10 @@ start(){
 		command+=" -f docker-compose.worker-cpu.yml"
 	fi
 
+ 	if [[ $ipv6 = true ]]; then
+        command+=" -f docker-compose.ipv6.yml"
+    	fi
+
 	command="$command up"
 
 	if [[ $detached = true ]]; then
@@ -480,6 +489,10 @@ down(){
 	else
 		command+=" -f docker-compose.nodeodm.yml"
 	fi
+
+ 	if [[ $ipv6 = true ]]; then
+        	command+=" -f docker-compose.ipv6.yml"
+    	fi
 
 	command+=" -f docker-compose.nodemicmac.yml down --remove-orphans"
 
@@ -583,6 +596,10 @@ elif [[ $1 = "stop" ]]; then
 	else
 		command+=" -f docker-compose.nodeodm.yml"
 	fi
+
+ 	if [[ $ipv6 = true ]]; then
+        	command+=" -f docker-compose.ipv6.yml"
+    	fi
 
 	command+=" -f docker-compose.nodemicmac.yml stop"
 	run "${command}"


### PR DESCRIPTION
Hello everyone,

In an effort to reduce costs (IPv4 shortage) and to align with a more modern network architecture, I would like to be able to use IPv6 with the WebODM/NodeODM pair.

Currently, I host a WebODM instance in Docker on a Debian 12 Linux server. When I need to generate a project, I create a remote NodeODM server and add the node to my WebODM server. All of this works fine in IPv4 (by default). However, when I add a NodeODM node that is only accessible via IPv6 (taking care to add the node as, for example, [2001:0db8:3c4d::abcd] in brackets in the interface, otherwise I get a 500 error), WebODM cannot communicate with the NodeODM server (no internal IPv6 connectivity).

In the current Nginx configuration, the server does not listen on the IPv6 layer. By default, it binds only to 0.0.0.0:8000 (IPv4), which prevents it from accepting IPv6 connections, even when Docker exposes the port on [::]:8000. This limitation blocks communication with IPv6-only nodes and restricts the ability to fully leverage IPv6 in WebODM deployments.