### PR TITLE
Sanitize import URLs

### DIFF
--- a/app/api/tasks.py
+++ b/app/api/tasks.py
@@ -623,8 +623,11 @@ class TaskAssetsImport(APIView):
         if not import_url and len(files) != 1:
             raise exceptions.ValidationError(detail=_("Cannot create task, you need to upload 1 file"))
 
-        if import_url and len(files) > 0:
-            raise exceptions.ValidationError(detail=_("Cannot create task, either specify a URL or upload 1 file."))
+        if import_url:
+            if len(files) > 0:
+                raise exceptions.ValidationError(detail=_("Cannot create task, either specify a URL or upload 1 file."))
+            if re.match(r"^https?:\/\/.+$", import_url.lower()) is None:
+                raise exceptions.ValidationError(detail=_("Invalid URL. Did you mean %(hint)s ?") % { 'hint': f'http://{import_url}'})
 
         chunk_index = request.data.get('dzchunkindex')
         uuid = request.data.get('dzuuid') 

--- a/app/static/app/js/components/ImportTaskPanel.jsx
+++ b/app/static/app/js/components/ImportTaskPanel.jsx
@@ -141,8 +141,12 @@ class ImportTaskPanel extends React.Component {
         this.setState({error: json.error || interpolate(_("Invalid JSON response: %(error)s"), {error: JSON.stringify(json)})});
       }
     })
-    .fail(() => {
-        this.setState({importingFromUrl: false, error: _("Cannot import from URL. Check your internet connection.")});
+    .fail((e) => {
+      let error = _("Cannot import from URL. Check your internet connection.");
+      if (e && e.responseJSON && Array.isArray(e.responseJSON) && e.responseJSON.length && typeof e.responseJSON[0] === 'string'){
+        error = e.responseJSON[0];
+      }
+      this.setState({importingFromUrl: false, error});
     });
   }
 

--- a/app/tests/test_api_task_import.py
+++ b/app/tests/test_api_task_import.py
@@ -125,6 +125,12 @@ class TestApiTask(BootTransactionTestCase):
             file_import_task.public = True
             file_import_task.save()
 
+            # Cannot import an invalid URL
+            res = client.post("/api/projects/{}/tasks/import".format(project.id), {
+                'url': "javascript:void(0)"
+            })
+            self.assertEqual(res.status_code, status.HTTP_400_BAD_REQUEST)
+
             # Import with URL method
             assets_import_url = "http://{}:{}/task/{}/download/all.zip".format(pnode.hostname, pnode.port, task_uuid)
             res = client.post("/api/projects/{}/tasks/import".format(project.id), {


### PR DESCRIPTION
If people mistakenly enter an invalid URL, sometimes the worker process gets stuck because requests throws exceptions that we don't catch. 