### PR TITLE
Docker compose deprecated "version" attribute + latest Tag + update config summary

### DIFF
--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -1,6 +1,6 @@
 # This configuration builds from Dockerfiles 
 # instead of pulling from opendronemap hub
-version: '2.1'
+
 services:
   db:
     build: ./db

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,4 +1,3 @@
-version: '2.1'
 services:
   webapp:
     entrypoint: /bin/bash -c "chmod +x /webodm/*.sh && /bin/bash -c \"/webodm/wait-for-postgres.sh db /webodm/wait-for-it.sh -t 0 broker:6379 -- /webodm/start.sh --create-default-pnode --setup-devenv\""

--- a/docker-compose.ipv6.yml
+++ b/docker-compose.ipv6.yml
@@ -1,4 +1,3 @@
-version: '2.2'
 networks:
   default:
     enable_ipv6: true

--- a/docker-compose.nodemicmac.yml
+++ b/docker-compose.nodemicmac.yml
@@ -1,8 +1,7 @@
-# Chaining this file to the main docker-compose file adds
+# Chaining this file to the main docker compose file adds
 # a default processing node instance. This is best for users
 # who are just getting started with WebODM.
 
-version: '2.1'
 services:
   webapp:
     depends_on:

--- a/docker-compose.nodeodm.gpu.intel.yml
+++ b/docker-compose.nodeodm.gpu.intel.yml
@@ -1,8 +1,7 @@
-# Chaining this file to the main docker-compose file adds
+# Chaining this file to the main docker compose file adds
 # a default processing node instance. This is best for users
 # who are just getting started with WebODM.
 
-version: '2.1'
 services:
   webapp:
     depends_on:

--- a/docker-compose.nodeodm.gpu.nvidia.yml
+++ b/docker-compose.nodeodm.gpu.nvidia.yml
@@ -1,8 +1,7 @@
-# Chaining this file to the main docker-compose file adds
+# Chaining this file to the main docker compose file adds
 # a default processing node instance. This is best for users
 # who are just getting started with WebODM.
 
-version: '2.1'
 services:
   webapp:
     depends_on:

--- a/docker-compose.nodeodm.yml
+++ b/docker-compose.nodeodm.yml
@@ -1,8 +1,7 @@
-# Chaining this file to the main docker-compose file adds
+# Chaining this file to the main docker compose file adds
 # a default processing node instance. This is best for users
 # who are just getting started with WebODM.
 
-version: '2.1'
 services:
   webapp:
     depends_on:

--- a/docker-compose.nodeodm.yml
+++ b/docker-compose.nodeodm.yml
@@ -9,7 +9,7 @@ services:
     environment:
       - WO_DEFAULT_NODES
   node-odm:
-    image: opendronemap/nodeodm
+    image: opendronemap/nodeodm:latest
     expose:
       - "3000"
     restart: unless-stopped

--- a/docker-compose.settings.yml
+++ b/docker-compose.settings.yml
@@ -1,4 +1,3 @@
-version: '2.1'
 services:
   webapp:
     volumes:

--- a/docker-compose.ssl-manual.yml
+++ b/docker-compose.ssl-manual.yml
@@ -1,5 +1,5 @@
 # This configuration adds the volumes necessary for SSL manual setup
-version: '2.1'
+
 services:
   webapp:
     volumes:

--- a/docker-compose.ssl.yml
+++ b/docker-compose.ssl.yml
@@ -1,5 +1,5 @@
 # This configuration adds support for SSL
-version: '2.1'
+
 volumes:
   letsencrypt:
     driver: local

--- a/docker-compose.worker-cpu.yml
+++ b/docker-compose.worker-cpu.yml
@@ -1,4 +1,3 @@
-version: '2.2'
 services:
   worker:
     cpus: ${WO_WORKER_CPUS}

--- a/docker-compose.worker-memory.yml
+++ b/docker-compose.worker-memory.yml
@@ -1,4 +1,3 @@
-version: '2.1'
 services:
   worker:
     mem_limit: ${WO_WORKER_MEMORY}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,11 @@
 # This configuration does not include a processing node
 # Which makes for faster setup times
-version: '2.1'
 volumes:
   dbdata:
   appmedia:
 services:
   db:
-    image: opendronemap/webodm_db
+    image: opendronemap/webodm_db:latest
     container_name: db
     expose:
       - "5432"
@@ -15,7 +14,7 @@ services:
     restart: unless-stopped
     oom_score_adj: -100
   webapp:
-    image: opendronemap/webodm_webapp
+    image: opendronemap/webodm_webapp:latest
     container_name: webapp
     entrypoint: /bin/bash -c "chmod +x /webodm/*.sh && /bin/bash -c \"/webodm/wait-for-postgres.sh db /webodm/wait-for-it.sh -t 0 broker:6379 -- /webodm/start.sh\""
     volumes:
@@ -37,12 +36,12 @@ services:
     restart: unless-stopped
     oom_score_adj: 0
   broker:
-    image: redis:7.0.10
+    image: redis:7.0.15
     container_name: broker
     restart: unless-stopped
     oom_score_adj: -500
   worker:
-    image: opendronemap/webodm_webapp
+    image: opendronemap/webodm_webapp:latest
     container_name: worker
     entrypoint: /bin/bash -c "/webodm/wait-for-postgres.sh db /webodm/wait-for-it.sh -t 0 broker:6379 -- /webodm/wait-for-it.sh -t 0 webapp:8000 -- /webodm/worker.sh start"
     volumes:

--- a/webodm.sh
+++ b/webodm.sh
@@ -150,6 +150,7 @@ case $key in
     ;;
     --ipv6)
     ipv6=true
+    export WO_IPV6=YES
     shift # past argument
     ;;
     *)    # unknown option
@@ -373,6 +374,7 @@ start(){
 	echo "================================"
 	echo "Host: $WO_HOST"
 	echo "Port: $WO_PORT"
+ 	echo "IPv6: $WO_IPV6"
 	echo "Media directory: $WO_MEDIA_DIR"
 	echo "Postgres DB directory: $WO_DB_DIR"
 	echo "SSL: $WO_SSL"


### PR DESCRIPTION
Hello!

I was constantly getting warning messages about the "version" attribute being obsolete in the latest version of Docker Compose. I’ve removed it from all the Docker Compose files. While it’s not a major blocking issue, this makes the script more aligned with the latest versions. 
Before :
![Capture d'écran 2025-03-31 115543](https://github.com/user-attachments/assets/ae1704d9-d9cf-4398-a52d-e2c8b727c1e0)
After :
![Capture d'écran 2025-03-31 130557](https://github.com/user-attachments/assets/e1d6fa25-1cce-49db-9bf3-0ce900b56ca9)

I’ve also specified image: opendronemap/imagename:latest with the "latest" tag, following official recommendations.

Added to the configuration summary the value IPV6: YES if it’s being used.

![Capture d'écran 2025-03-31 130731](https://github.com/user-attachments/assets/4a8a7712-1a32-46a3-8485-3b7f67b4d3d2)

+ Update Redis to 7.0.15 (previous 7.0.10)



