### PR TITLE
Orphaned project folders handling

### DIFF
--- a/app/models/project.py
+++ b/app/models/project.py
@@ -40,7 +40,7 @@ class Project(models.Model):
         if self.task_set.count() == 0:
             # Just delete normally
 
-            project_dir = os.path.join(wo_settings.MEDIA_ROOT, "project", str(self.id))
+            project_dir = self.get_project_dir()
             if os.path.isdir(project_dir):
                 entries = os.listdir(project_dir)
                 empty_project_folder = False
@@ -74,6 +74,12 @@ class Project(models.Model):
     def __str__(self):
         return self.name
 
+    def get_project_dir(self):
+        if self.id is None:
+            raise ValueError("Cannot call get_project_dir, id is None")
+        
+        return os.path.join(wo_settings.MEDIA_ROOT, "project", str(self.id))
+
     def tasks(self):
         return self.task_set.only('id')
 
@@ -103,6 +109,9 @@ class Project(models.Model):
                 project.created_at = timezone.now()
                 if new_owner is not None:
                     project.owner = new_owner
+                project.public_id = None
+                project.public_edit = False
+                project.public = False
                 project.save()
                 project.refresh_from_db()
 

--- a/app/models/task.py
+++ b/app/models/task.py
@@ -980,7 +980,6 @@ class Task(models.Model):
             # Check if the zip file contained a top level directory
             # which shouldn't be there and try to fix the structure
             top_level = [os.path.join(assets_dir, d) for d in os.listdir(assets_dir)]
-            logger.info(top_level)
             if len(top_level) == 1 and os.path.isdir(top_level[0]):
                 second_level = [os.path.join(top_level[0], f) for f in os.listdir(top_level[0])]
                 if len(second_level) > 0:

--- a/worker/tasks.py
+++ b/worker/tasks.py
@@ -62,23 +62,24 @@ def update_nodes_info():
 def cleanup_projects():
     # Delete all projects that are marked for deletion
     # and that have no tasks left
-    total, count_dict = Project.objects.filter(deleting=True).annotate(
+    deletion_projects = Project.objects.filter(deleting=True).annotate(
         tasks_count=Count('task')
-    ).filter(tasks_count=0).delete()
-    if total > 0 and 'app.Project' in count_dict:
-        logger.info("Deleted {} projects".format(count_dict['app.Project']))
+    ).filter(tasks_count=0)
+    for p in deletion_projects:
+        p.delete()     
 
     # Delete projects that have no tasks and are owned by users with
     # no disk quota
     if settings.CLEANUP_EMPTY_PROJECTS is not None:
-        total, count_dict = Project.objects.filter(
+        empty_projects = Project.objects.filter(
             owner__profile__quota=0,
             created_at__lte=timezone.now() - timedelta(hours=settings.CLEANUP_EMPTY_PROJECTS)
         ).annotate(
             tasks_count=Count('task')
-        ).filter(tasks_count=0).delete()
-        if total > 0 and 'app.Project' in count_dict:
-            logger.info("Deleted {} projects".format(count_dict['app.Project']))
+        ).filter(tasks_count=0)
+        for p in empty_projects:
+            p.delete()
+
 
 @app.task(ignore_result=True)
 def cleanup_tasks():


### PR DESCRIPTION
Creating a project currently leaves a bunch of orphaned folders due to the software not removing the references to them on deletion.

This PR fixes that, as well as providing an utility to cleanup orphaned folders.