### PR TITLE
Intersection over area project map display

### DIFF
--- a/app/api/tasks.py
+++ b/app/api/tasks.py
@@ -89,14 +89,7 @@ class TaskSerializer(serializers.ModelSerializer):
         return []
 
     def get_extent(self, obj):
-        if obj.orthophoto_extent is not None:
-            return obj.orthophoto_extent.extent
-        elif obj.dsm_extent is not None:
-            return obj.dsm_extent.extent
-        elif obj.dtm_extent is not None:
-            return obj.dsm_extent.extent
-        else:
-            return None
+        return obj.get_extent()
 
     class Meta:
         model = models.Task

--- a/app/models/task.py
+++ b/app/models/task.py
@@ -374,6 +374,16 @@ class Task(models.Model):
         self.validate_unique()
 
         super(Task, self).save(*args, **kwargs)
+    
+    def get_extent(self):
+        if self.orthophoto_extent is not None:
+            return self.orthophoto_extent.extent
+        elif self.dsm_extent is not None:
+            return self.dsm_extent.extent
+        elif self.dtm_extent is not None:
+            return self.dsm_extent.extent
+        else:
+            return None
 
     def assets_path(self, *args):
         """
@@ -1097,7 +1107,8 @@ class Task(models.Model):
                     'ground_control_points': ground_control_points,
                     'epsg': self.epsg,
                     'orthophoto_bands': self.orthophoto_bands,
-                    'crop': self.crop is not None
+                    'crop': self.crop is not None,
+                    'extent': self.get_extent(),
                 }
             }
         }

--- a/app/static/app/js/components/LayersControlLayer.jsx
+++ b/app/static/app/js/components/LayersControlLayer.jsx
@@ -17,7 +17,7 @@ export default class LayersControlLayer extends React.Component {
       expanded: false,
       map: null,
       overlay: false,
-      separator: false,
+      separator: false
   };
   static propTypes = {
     layer: PropTypes.object.isRequired,
@@ -81,9 +81,25 @@ export default class LayersControlLayer extends React.Component {
     PluginsAPI.Map.onSideBySideChanged(this.handleSideBySideChange);
   }
 
+  isLayerWithSameTaskIdVisible = () => {
+    if (!this.meta.task) return true;
+
+    const taskId = this.meta.task.id;
+    for (let layer of Object.values(this.props.map._layers)){
+        if (!layer[Symbol.for("meta")] || !layer.isHidden) continue;
+        const meta = layer[Symbol.for("meta")];
+        if (meta.task.id === taskId && 
+            this.props.map.hasLayer(layer) && 
+            !layer.isHidden()){
+            return true;
+        }
+    }
+    return false;
+  }
+
   handleMapTypeChange = (type, autoExpand) => {
     if (this.meta.type !== undefined){
-        const visible = this.meta.type === type;
+        const visible = this.meta.type === type && (autoExpand || this.isLayerWithSameTaskIdVisible());
         const expanded = visible && autoExpand;
         this.setState({visible, expanded});
     }

--- a/app/static/app/js/components/Map.jsx
+++ b/app/static/app/js/components/Map.jsx
@@ -151,6 +151,28 @@ class Map extends React.Component {
     return true;
   }
 
+  computeIOU = (b1, b2) => {
+    const [x1Min, y1Min, x1Max, y1Max] = b1;
+    const [x2Min, y2Min, x2Max, y2Max] = b2;
+  
+    const interXMin = Math.max(x1Min, x2Min);
+    const interYMin = Math.max(y1Min, y2Min);
+    const interXMax = Math.min(x1Max, x2Max);
+    const interYMax = Math.min(y1Max, y2Max);
+  
+    const interWidth = Math.max(0, interXMax - interXMin);
+    const interHeight = Math.max(0, interYMax - interYMin);
+    const interArea = interWidth * interHeight;
+  
+    const area1 = (x1Max - x1Min) * (y1Max - y1Min);
+    const area2 = (x2Max - x2Min) * (y2Max - y2Min);
+    const unionArea = area1 + area2 - interArea;
+  
+    if (unionArea === 0) return 0;
+  
+    return interArea / unionArea;
+  }
+
   loadImageryLayers(forceAddLayers = false){
     // Cancel previous requests
     if (this.tileJsonRequests) {
@@ -191,6 +213,28 @@ class Map extends React.Component {
         }
       }
 
+      // Compute IoU scores
+      // This gives us an idea of overlap between tasks
+      // so that we can decide to show them in project map view
+      const ious = {};
+      for (let i = tiles.length - 1; i >= 0; i--){
+        const taskId = tiles[i].meta.task.id;
+        if (ious[taskId] === undefined){
+          for (let j = i - 1; j >= 0; j--){
+            const tId = tiles[j].meta.task.id;
+            if (tId === taskId) continue;
+            
+            const iou = this.computeIOU(tiles[i].meta.task.extent, tiles[j].meta.task.extent);
+            if (ious[taskId] === undefined){
+              ious[taskId] = iou;
+            }else{
+              ious[taskId] = Math.max(ious[taskId], iou);
+            }
+          }
+        }
+      }
+      ious[tiles[0].meta.task.id] = 0; // First element is always visible
+      
       async.each(tiles, (tile, done) => {
         const { url, type, zIndexGroup } = tile;
         const meta = Utils.clone(tile.meta);
@@ -289,7 +333,7 @@ class Map extends React.Component {
                 if (meta.task.crop) params.crop = 1;
                 tileUrl = Utils.buildUrlWithQuery(tileUrl, params);
             }
-            
+
             const layer = Leaflet.tileLayer(tileUrl, {
                   bounds,
                   minZoom: 0,
@@ -323,8 +367,9 @@ class Map extends React.Component {
             layer[Symbol.for("meta")] = meta;
             layer[Symbol.for("tile-meta")] = mres;
 
+            const iou = ious[meta.task.id] || 0;
             if (forceAddLayers || prevSelectedLayers.indexOf(layerId(layer)) !== -1){
-              if (type === this.props.mapType){
+              if (type === this.props.mapType && iou <= 0.8){
                 layer.addTo(this.map);
               }
             }


### PR DESCRIPTION
This PR improves the project map display by computing IOU scores on map items in order to decide whether to display them or not. 

* When lots of tasks are stacked on top of each other, it only displays the top-most layer by default
* When the map type buttons are pressed, only the layers in the same taskID group are toggled, rather than toggling them all on/off
* Only show annotations for top-most layers (depending on IOU score)
