### PR TITLE
Avoid locking users out of a map with an invalid crop

### DIFF
--- a/app/api/tiler.py
+++ b/app/api/tiler.py
@@ -211,6 +211,13 @@ class Metadata(TaskNestedView):
                 info = json.loads(metadata.json())
         except IndexError as e:
             # Caught when trying to get an invalid raster metadata
+            # or when the crop area is defined improperly. In order
+            # to avoid locking the user out of the map, we remove cropping
+            # if this ever happens.
+            if task.crop is not None:
+                task.crop = None
+                task.save()
+            
             raise exceptions.ValidationError("Cannot retrieve raster metadata: %s" % str(e))
         # Override min/max
         if hrange:


### PR DESCRIPTION
Simple but effective fix for the case when a user draws a crop polygon boundary within the extents of a raster's bounding box, but without actually selecting any of the pixels of the raster (thus passing the validation checks in the Task model). This causes users to get locked out of a map, which is bad. 

In this scenario, we reset the crop.