### PR TITLE
Multispectral fixes + crop fixes

### DIFF
--- a/app/api/tasks.py
+++ b/app/api/tasks.py
@@ -563,7 +563,7 @@ class TaskThumbnail(TaskNestedView):
 
         if img.dtype != np.uint8:
             img = img.astype(np.float32)
-            
+
             # Ignore alpha values
             minval = img[:,:,:3].min()
             maxval = img[:,:,:3].max()
@@ -571,6 +571,10 @@ class TaskThumbnail(TaskNestedView):
             if minval != maxval:
                 img[:,:,:3] -= minval
                 img[:,:,:3] *= (255.0/(maxval-minval))
+
+            # Normalize alpha
+            if img.shape[2] == 4:
+                img[:,:,3] = np.where(img[:,:,3]==0, 0, 255)
             
             img = img.astype(np.uint8)
 

--- a/app/api/tasks.py
+++ b/app/api/tasks.py
@@ -532,13 +532,12 @@ class TaskThumbnail(TaskNestedView):
                     out_width = int(thumb_size * ratio)
 
 
-                with WarpedVRT(raster, cutline=cutline) as vrt:
+                with WarpedVRT(raster, cutline=cutline, nodata=0) as vrt:
                     rgb = vrt.read(indexes=indexes, window=win, fill_value=0, out_shape=(
                         len(indexes),
                         out_height,
                         out_width,
                     ), resampling=rasterio.enums.Resampling.nearest)
-                
                 img = np.zeros((len(indexes), thumb_size, thumb_size), dtype=rgb.dtype)
                 y_offset = (thumb_size - out_height) // 2
                 x_offset = (thumb_size - out_width) // 2
@@ -558,7 +557,7 @@ class TaskThumbnail(TaskNestedView):
                     thumb_size,
                     thumb_size,
                 ), resampling=rasterio.enums.Resampling.nearest)
-            
+
             img = img.transpose((1, 2, 0))
 
         if img.dtype != np.uint8:

--- a/app/api/tiler.py
+++ b/app/api/tiler.py
@@ -435,7 +435,7 @@ class Tiles(TaskNestedView):
                                     tile_buffer=tile_buffer,
                                     resampling_method=resampling, vrt_options=vrt_options)
                 else:
-                    tile = src.tile(x, y, z, tilesize=tilesize, nodata=nodata,
+                    tile = src.tile(x, y, z, indexes=indexes, tilesize=tilesize, nodata=nodata,
                                     padding=padding,
                                     tile_buffer=tile_buffer,
                                     resampling_method=resampling, vrt_options=vrt_options)

--- a/app/models/task.py
+++ b/app/models/task.py
@@ -987,7 +987,7 @@ class Task(models.Model):
             # Check if the zip file contained a top level directory
             # which shouldn't be there and try to fix the structure
             top_level = [os.path.join(assets_dir, d) for d in os.listdir(assets_dir)]
-            if len(top_level) == 1 and os.path.isdir(top_level[0]):
+            if len(top_level) == 1 and os.path.isdir(top_level[0]) and top_level[0][-14:] != "odm_orthophoto":
                 second_level = [os.path.join(top_level[0], f) for f in os.listdir(top_level[0])]
                 if len(second_level) > 0:
                     logger.info("Top level directory found in imported archive, attempting to fix")

--- a/app/models/task.py
+++ b/app/models/task.py
@@ -987,7 +987,7 @@ class Task(models.Model):
             # Check if the zip file contained a top level directory
             # which shouldn't be there and try to fix the structure
             top_level = [os.path.join(assets_dir, d) for d in os.listdir(assets_dir)]
-            if len(top_level) == 1 and os.path.isdir(top_level[0]) and top_level[0][-14:] != "odm_orthophoto":
+            if len(top_level) == 1 and os.path.isdir(top_level[0]) and (not top_level[0].endswith("odm_orthophoto")):
                 second_level = [os.path.join(top_level[0], f) for f in os.listdir(top_level[0])]
                 if len(second_level) > 0:
                     logger.info("Top level directory found in imported archive, attempting to fix")

--- a/app/raster_utils.py
+++ b/app/raster_utils.py
@@ -47,7 +47,7 @@ def export_raster(input, output, **opts):
             crop = GEOSGeometry(crop_wkt)
             crop.srid = 4326
             cutline, bounds = geom_transform_wkt_bbox(crop, ds, 'raster')
-            vrt_options = {'cutline': cutline}
+            vrt_options = {'cutline': cutline, 'nodata': 0}
     else:
         vrt_options = None
     

--- a/app/static/app/js/components/LayersControlLayer.jsx
+++ b/app/static/app/js/components/LayersControlLayer.jsx
@@ -288,7 +288,8 @@ export default class LayersControlLayer extends React.Component {
         bands,
         hillshade,
         rescale: this.rescale,
-        size: 512
+        size: 512,
+        crop: 1
     };
   }
   

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "WebODM",
-  "version": "2.8.2",
+  "version": "2.8.3",
   "description": "User-friendly, extendable application and API for processing aerial imagery.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
 * Fixes tile rendering for 16bit MS orthophotos with > 3 bands (closes #1676)
 * Fixes thumbnail rendering for 16bit MS orthophotos
 * Fixes an issue removing crop when scaling raster band ranges from the layer list (crop=1 is not sent to the server)
 * Fixes an issue with exporting cropped 16bit MS orthophotos due to a problem with WarpedVRT scaling the band values (related: https://github.com/rasterio/rasterio/issues/2104)