### PR TITLE
Docker on steroids

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,13 @@
-**/.git
-.secret_key
-node_modules/
+**/.git/
+**/node_modules/
+**/.ruff_cache/
+**/__pycache__/
+**/.github/
 .venv/
+.secret_key
+slate/
+service/
+screenshots/
+db/
+dpkg/
+build/

--- a/app/scripts/extract_plugin_manifest_strings.py
+++ b/app/scripts/extract_plugin_manifest_strings.py
@@ -16,7 +16,7 @@ def extract_plugin_manifest_strings(plugins_dir, output):
     print("Found %s manifest strings" % len(strings))
     if len(strings) > 0:
         with open(output, "w") as f:
-            f.write("// Auto-generated with extract_plugin_manifest_strings.py, do not edit!\n\n")
+            f.write("# Auto-generated with extract_plugin_manifest_strings.py, do not edit!\n\n")
             f.write("from django.utils.translation import gettext as _\n")
             
             for s in strings:

--- a/app/translations/plugin_manifest_autogenerated.py
+++ b/app/translations/plugin_manifest_autogenerated.py
@@ -1,4 +1,4 @@
-// Auto-generated with extract_plugin_manifest_strings.py, do not edit!
+# Auto-generated with extract_plugin_manifest_strings.py, do not edit!
 
 from django.utils.translation import gettext as _
 _("Upload and tile ODM assets with Cesium ion.")


### PR DESCRIPTION
This builds on from #1672 and will show up clean once that's been merged.

It features:
- More strongly layered Docker build enabling MUCH more aggressive caching.  Last (warm) build was running in 1s(!)
- Additional space savings, we're now at 1.65 GB.
- Runs as a non-privileged user.
- Compiles Python into byte-code for quicker starts.
- Includes a fix for JS comment lingering in Python file.
- Expect huge speedups with cache on GH actions enabled.