### PR TITLE
Allow selectively testing (parts) front/backend with arguments

### DIFF
--- a/webodm.sh
+++ b/webodm.sh
@@ -528,6 +528,7 @@ run_tests(){
             echo -e "\033[1mDone!\033[0m Everything looks in order."
         fi
     else
+		environment_check
         echo "Running tests in webapp container"
         run "$docker_compose exec webapp /bin/bash -c \"/webodm/webodm.sh test $@\""
     fi

--- a/webodm.sh
+++ b/webodm.sh
@@ -515,12 +515,12 @@ run_tests(){
         
         if [[ $test_type = "frontend" || $test_type = "all" ]]; then
             echo -e "\033[1mRunning frontend tests\033[0m"
-            run "npm run test $@"
+            run "npm run test $*"
         fi
 
         if [[ $test_type = "backend" || $test_type = "all" ]]; then
             echo -e "\033[1mRunning backend tests\033[0m"
-            run "python manage.py test $@"
+            run "python manage.py test $*"
         fi
 
         if [[ $test_type = "all" ]]; then
@@ -530,7 +530,8 @@ run_tests(){
     else
 		environment_check
         echo "Running tests in webapp container"
-        run "$docker_compose exec webapp /bin/bash -c \"/webodm/webodm.sh test $@\""
+        test_command="/webodm/webodm.sh test $*"
+        run "$docker_compose exec webapp /bin/bash -c \"$test_command\""
     fi
 }
 


### PR DESCRIPTION
Allow selective running of frontend and/or backend tests as well as passing arbitrary arguments to test commands, e.g. to run selective (failing) tests faster.

Tested to pass arguments through to the same command in Docker.

Example: `./webodm.sh test backend app.tests.TestApi`

(Not sure this is the exact path of the test, but the idea should be clear.)