### PR TITLE
Improvements to raster exports

### DIFF
--- a/app/raster_utils.py
+++ b/app/raster_utils.py
@@ -162,11 +162,6 @@ def export_raster(input, output, **opts):
                 indexes = (ci.index(ColorInterp.gray) + 1,) * 3 + \
                            (ci.index(ColorInterp.alpha) + 1, )
 
-        if ColorInterp.alpha in ci:
-            mask = reader.read(ci.index(ColorInterp.alpha) + 1, window=win)
-        else:
-            mask = reader.dataset_mask(window=win)
-
         cmap = None
         if color_map:
             try:
@@ -240,7 +235,7 @@ def export_raster(input, output, **opts):
 
             def write_to(arr, dst):
                 reproject(source=arr, 
-                        destination=dst,
+                        destination=rasterio.band(dst, indexes),
                         src_transform=win_transform,
                         src_crs=src.crs,
                         dst_transform=transform,

--- a/app/raster_utils.py
+++ b/app/raster_utils.py
@@ -128,6 +128,7 @@ def export_raster(input, output, **opts):
         driver = "GTiff"
         compress = None
         max_bands = 9999
+        window_size = 512
         with_alpha = True
         rgb = False
         indexes = src.indexes
@@ -348,11 +349,10 @@ def export_raster(input, output, **opts):
         else:
             # Copy bands as-is
             with rasterio.open(output_raster, 'w', **profile) as dst:
-                subwins = compute_subwindows(win, 512)
+                subwins = compute_subwindows(win, window_size)
                 for w in subwins:
                     arr = reader.read(indexes=indexes, window=w)
-                    dst_w = Window(w.col_off - win.col_off, w.row_off - win.row_off,
-                                    w.width, w.height)
+                    dst_w = Window(w.col_off - win.col_off, w.row_off - win.row_off, w.width, w.height)
                     dst.write(process(arr), window=dst_w)
 
                 new_ci = [src.colorinterp[idx - 1] for idx in indexes]

--- a/app/raster_utils.py
+++ b/app/raster_utils.py
@@ -399,7 +399,7 @@ def export_raster(input, output, progress_callback=None, **opts):
         elif reproject:
             output_vrt = path_base + ".vrt"
 
-            subprocess.check_output(["gdalwarp", "-r", "near", 
+            subprocess.check_output(["gdalwarp", "-r", "near" if resampling == "nearest" else resampling, 
                                     "-of", "VRT",
                                     "-t_srs", f"EPSG:{epsg}",
                                     output_raster, output_vrt])

--- a/app/raster_utils.py
+++ b/app/raster_utils.py
@@ -8,13 +8,12 @@ import numexpr as ne
 import time
 from django.contrib.gis.geos import GEOSGeometry
 from rasterio.enums import ColorInterp
-from rasterio.windows import Window, bounds as window_bounds, from_bounds
+from rasterio.windows import Window
 from rio_tiler.utils import has_alpha_band, linear_rescale
 from rio_tiler.colormap import cmap as colormap, apply_cmap
 from rio_tiler.errors import InvalidColorMapName
 from app.api.hsvblend import hsv_blend
 from app.api.hillshade import LightSource
-from rasterio.warp import calculate_default_transform
 from rio_tiler.io import COGReader
 
 logger = logging.getLogger('app.logger')

--- a/app/raster_utils.py
+++ b/app/raster_utils.py
@@ -245,7 +245,10 @@ def export_raster(input, output, **opts):
 
         def process(arr, skip_rescale=False, skip_background=False, skip_type=False, mask=None, includes_alpha=True, drop_last_band=False):
             if not skip_rescale and rescale is not None:
-                arr = linear_rescale(arr, in_range=rescale)
+                if includes_alpha:
+                    arr[:-1, :, :] = linear_rescale(arr[:-1, :, :], in_range=rescale)
+                else:
+                    arr = linear_rescale(arr, in_range=rescale)
             if not skip_background and (mask is not None or includes_alpha):
                 if mask is not None:
                     background = mask==0
@@ -256,6 +259,9 @@ def export_raster(input, output, **opts):
                 else:
                     arr[:, background] = jpg_background
             if not skip_type and rgb and arr.dtype != np.uint8:
+                if includes_alpha:
+                    arr[-1][arr[-1] > 255] = 255
+                    
                 arr = arr.astype(np.uint8)
             
             if drop_last_band:

--- a/app/static/app/js/components/ExportAssetPanel.jsx
+++ b/app/static/app/js/components/ExportAssetPanel.jsx
@@ -76,7 +76,8 @@ export default class ExportAssetPanel extends React.Component {
         epsg: this.props.task.epsg || null,
         customEpsg: Storage.getItem("last_export_custom_epsg") || "4326",
         resample: 0,
-        exporting: false
+        exporting: false,
+        progress: null
     }
   }
 
@@ -132,7 +133,7 @@ export default class ExportAssetPanel extends React.Component {
         if (typeof cb !== 'function') cb = undefined;
         
         const { task } = this.props;
-        this.setState({exporting: true, error: ""});
+        this.setState({exporting: true, error: "", progress: null});
         const data = this.getExportParams(format);
 
         if (this.state.epsg === "custom") Storage.setItem("last_export_custom_epsg", data.epsg);
@@ -152,6 +153,8 @@ export default class ExportAssetPanel extends React.Component {
                             Workers.downloadFile(result.celery_task_id, result.filename);
                             if (cb !== undefined) cb();
                         }
+                    }, (_, progress) => {
+                      this.setState({progress});
                     });
                 }else if (result.url){
                     // Simple download
@@ -182,7 +185,7 @@ export default class ExportAssetPanel extends React.Component {
   }
 
   render(){
-    const {epsg, customEpsg, exporting, format, resample } = this.state;
+    const {epsg, customEpsg, exporting, format, resample, progress } = this.state;
     const { exportFormats } = this.props;
     const utmEPSG = this.props.task.epsg;
 
@@ -233,7 +236,7 @@ export default class ExportAssetPanel extends React.Component {
             <div className={"btn-group " + (this.props.dropUp ?  "dropup" : "")}>
                 <button onClick={this.handleExport(exportFormats[0])}
                     disabled={disabled} type="button" className="btn btn-sm btn-primary btn-export">
-                    {exporting ? <i className="fa fa-spin fa-circle-notch"/> : <i className={this.efInfo[exportFormats[0]].icon + " fa-fw"}/>} {exporting ? _("Exporting...") : this.efInfo[exportFormats[0]].label}
+                    {exporting ? <i className="fa fa-spin fa-circle-notch"/> : <i className={this.efInfo[exportFormats[0]].icon + " fa-fw"}/>} {exporting ? _("Exporting...") : this.efInfo[exportFormats[0]].label} {exporting && progress !== null ? ` (${progress.toFixed(0)}%)` : ""}
                 </button>
                 <button disabled={disabled} type="button" className="btn btn-sm dropdown-toggle btn-primary" data-toggle="dropdown"><span className="caret"></span></button>
                 <ul className="dropdown-menu pull-right">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "WebODM",
-  "version": "2.8.4",
+  "version": "2.9.0",
   "description": "User-friendly, extendable application and API for processing aerial imagery.",
   "main": "index.js",
   "scripts": {

--- a/worker/tasks.py
+++ b/worker/tasks.py
@@ -195,7 +195,10 @@ def export_raster(self, input, **opts):
     try:
         logger.info("Exporting raster {} with options: {}".format(input, json.dumps(opts)))
         tmpfile = tempfile.mktemp('_raster.{}'.format(extension_for_export_format(opts.get('format', 'gtiff'))), dir=settings.MEDIA_TMP)
-        export_raster_sync(input, tmpfile, **opts)
+        def progress_callback(status, perc):
+            self.update_state(state="PROGRESS", meta={"status": status, "progress": perc})
+        
+        export_raster_sync(input, tmpfile, progress_callback=progress_callback, **opts)
         result = {'file': tmpfile}
 
         if settings.TESTING:
@@ -203,7 +206,7 @@ def export_raster(self, input, **opts):
 
         return result
     except Exception as e:
-        logger.error(traceback.format_exc())
+        # logger.error(traceback.format_exc())
         logger.error(str(e))
         return {'error': str(e)}
 

--- a/worker/tasks.py
+++ b/worker/tasks.py
@@ -203,6 +203,7 @@ def export_raster(self, input, **opts):
 
         return result
     except Exception as e:
+        logger.error(traceback.format_exc())
         logger.error(str(e))
         return {'error': str(e)}
 

--- a/worker/tasks.py
+++ b/worker/tasks.py
@@ -206,7 +206,7 @@ def export_raster(self, input, **opts):
 
         return result
     except Exception as e:
-        logger.error(traceback.format_exc()) # TODO uncomment
+        # logger.error(traceback.format_exc())
         logger.error(str(e))
         return {'error': str(e)}
 

--- a/worker/tasks.py
+++ b/worker/tasks.py
@@ -206,7 +206,7 @@ def export_raster(self, input, **opts):
 
         return result
     except Exception as e:
-        # logger.error(traceback.format_exc())
+        logger.error(traceback.format_exc()) # TODO uncomment
         logger.error(str(e))
         return {'error': str(e)}
 


### PR DESCRIPTION
This PR improves raster exports by using tiles, thus reducing memory usage and preventing OOM errors with very large raster exports.

This also adds the ability to get a progress % update on the export.

Uses bilinear interpolation for reprojection to other CRSes.

Closes #1580, #1340, #1494