### PR TITLE
Catch file not found error on task import

### DIFF
--- a/app/models/task.py
+++ b/app/models/task.py
@@ -651,7 +651,7 @@ class Task(models.Model):
 
         try:
             self.extract_assets_and_complete()
-        except zipfile.BadZipFile:
+        except (zipfile.BadZipFile, FileNotFoundError):
             raise NodeServerError(gettext("Invalid zip file"))
         except NotImplementedError:
             raise NodeServerError(gettext("Unsupported compression method"))


### PR DESCRIPTION
Sometimes this exception might be raised when importing an invalid task asset