### PR TITLE
Improve cache hits during raster export

### DIFF
--- a/app/raster_utils.py
+++ b/app/raster_utils.py
@@ -87,7 +87,7 @@ def compute_block_aligned_subwindows(src, win):
 def padded_window(w, pad):
     return Window(w.col_off - pad, w.row_off - pad, w.width + pad * 2, w.height + pad * 2)
 
-def export_raster(input, output, progress_callback=None, is_aborted=None, **opts):
+def export_raster(input, output, progress_callback=None, **opts):
     now = time.time()
 
     current_progress = 0
@@ -313,8 +313,6 @@ def export_raster(input, output, progress_callback=None, is_aborted=None, **opts
 
             with rasterio.open(output_raster, 'w', **profile) as dst:
                 for idx, (w, dst_w) in enumerate(subwins):
-                    if is_aborted is not None and is_aborted():
-                        return
                     p(f"Processing tile {idx}/{num_wins}", progress_per_win)
 
                     data = src.read(indexes=indexes, window=w, out_dtype=np.float32)
@@ -352,8 +350,6 @@ def export_raster(input, output, progress_callback=None, is_aborted=None, **opts
             # Apply hillshading, colormaps to elevation
             with rasterio.open(output_raster, 'w', **profile) as dst:
                 for idx, (w, dst_w) in enumerate(subwins):
-                    if is_aborted is not None and is_aborted():
-                        return
                     p(f"Processing tile {idx}/{num_wins}", progress_per_win)
 
                     # Apply colormap?
@@ -406,8 +402,6 @@ def export_raster(input, output, progress_callback=None, is_aborted=None, **opts
             # Copy bands as-is
             with rasterio.open(output_raster, 'w', **profile) as dst:
                 for idx, (w, dst_w) in enumerate(subwins):
-                    if is_aborted is not None and is_aborted():
-                        return
                     p(f"Processing tile {idx}/{num_wins}", progress_per_win)
 
                     arr = src.read(indexes=indexes, window=w)

--- a/worker/tasks.py
+++ b/worker/tasks.py
@@ -20,6 +20,7 @@ from nodeodm.models import ProcessingNode
 from webodm import settings
 import worker
 from .celery import app
+from celery.contrib.abortable import AbortableTask
 from app.raster_utils import export_raster as export_raster_sync, extension_for_export_format
 from app.pointcloud_utils import export_pointcloud as export_pointcloud_sync
 from django.utils import timezone
@@ -190,15 +191,17 @@ def process_pending_tasks():
         process_task.delay(task.id)
 
 
-@app.task(bind=True, time_limit=settings.WORKERS_MAX_TIME_LIMIT)
+@app.task(bind=True, time_limit=settings.WORKERS_MAX_TIME_LIMIT, base=AbortableTask)
 def export_raster(self, input, **opts):
     try:
         logger.info("Exporting raster {} with options: {}".format(input, json.dumps(opts)))
         tmpfile = tempfile.mktemp('_raster.{}'.format(extension_for_export_format(opts.get('format', 'gtiff'))), dir=settings.MEDIA_TMP)
         def progress_callback(status, perc):
             self.update_state(state="PROGRESS", meta={"status": status, "progress": perc})
+        def is_aborted():
+            return self.is_aborted()
         
-        export_raster_sync(input, tmpfile, progress_callback=progress_callback, **opts)
+        export_raster_sync(input, tmpfile, progress_callback=progress_callback, is_aborted=is_aborted, **opts)
         result = {'file': tmpfile}
 
         if settings.TESTING:


### PR DESCRIPTION
Improves export performance by making sure the read windows are cache aligned (swapping X with Y does the trick).

