### PR TITLE
Change parallel uploads 6 --> 4

### DIFF
--- a/app/static/app/js/components/ProjectListItem.jsx
+++ b/app/static/app/js/components/ProjectListItem.jsx
@@ -138,7 +138,7 @@ class ProjectListItem extends React.Component {
       this.dz = new Dropzone(this.dropzone, {
           paramName: "images",
           url : 'TO_BE_CHANGED',
-          parallelUploads: 6,
+          parallelUploads: 4,
           uploadMultiple: false,
           acceptedFiles: "image/*,text/plain,.las,.laz,video/*,.srt",
           autoProcessQueue: false,


### PR DESCRIPTION
If a person starts multiple uploads from the same browser window, this can lock the UI because we quickly reach the maximum number of requests that a browser can handle.

So I'm reducing the number to mitigate this a bit.