### PR TITLE
Fix GeoJSON axis swap, invalidate tile cache during crop

### DIFF
--- a/app/raster_utils.py
+++ b/app/raster_utils.py
@@ -124,20 +124,13 @@ def export_raster(input, output, progress_callback=None, **opts):
 
     if crop_wkt is not None:
         crop = GEOSGeometry(crop_wkt)
-        crop.srid = 4326
 
         crop_geojson = os.path.join(path_base, "crop.geojson")
         raster_vrt = os.path.join(path_base, "raster.vrt")
 
         os.makedirs(os.path.dirname(crop_geojson), exist_ok=True)
         with open(crop_geojson, "w", encoding="utf-8") as f:
-            j = json.loads(crop.geojson)
-
-            # Swap lat/lon
-            for i, c in enumerate(j["coordinates"]):
-                j["coordinates"][i] = [[y,x] for x,y in c]
-            
-            f.write(json.dumps(j))
+            f.write(crop.geojson)
 
         subprocess.check_output(["gdalwarp", "-cutline", crop_geojson,
                 '--config', 'GDALWARP_DENSIFY_CUTLINE', 'NO', 

--- a/app/static/app/js/components/CropButton.jsx
+++ b/app/static/app/js/components/CropButton.jsx
@@ -185,7 +185,7 @@ class CropButton extends React.Component {
     deletePolygon = (opts = {}) => {
         if (this.polygon){
             const remove = () => {
-                this.group.removeLayer(this.polygon);
+                if (this.polygon !== null) this.group.removeLayer(this.polygon);
                 this.polygon = null;
                 if (opts.triggerEvents) this.props.onPolygonChange(null);
             };

--- a/app/static/app/js/components/Map.jsx
+++ b/app/static/app/js/components/Map.jsx
@@ -330,10 +330,11 @@ class Map extends React.Component {
                 }
                 
                 params.size = TILESIZE;
+                params.cache = Math.floor(Math.random() * 1000000); // cache bust
                 if (meta.task.crop) params.crop = 1;
                 tileUrl = Utils.buildUrlWithQuery(tileUrl, params);
             }else{
-                let params = { size: TILESIZE };
+                let params = { size: TILESIZE, cache: Math.floor(Math.random() * 1000000) };
                 if (meta.task.crop) params.crop = 1;
                 tileUrl = Utils.buildUrlWithQuery(tileUrl, params);
             }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "WebODM",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "description": "User-friendly, extendable application and API for processing aerial imagery.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
* Fixes a problem with the GeoJSON X/Y being swapped for some unknown reason (follow up to #1739 ) in the contours and objdetect plugins
* Invalidate the tile URLs when cropping, otherwise some browsers try to cleverly bypass making a request for new tiles and the cropping in the map does not show properly.