### PR TITLE
Allow all annotations to be displayed

### DIFF
--- a/app/static/app/js/components/Map.jsx
+++ b/app/static/app/js/components/Map.jsx
@@ -930,7 +930,7 @@ _('Example:'),
         
         if (stored){
           // Only show annotations for top-most tasks
-          if (this.ious[task.id] >= 0.01 && !(annotationsVisibility === "all")){
+          if (this.ious[task.id] >= 0.01 && annotationsVisibility !== "all"){
             PluginsAPI.Map.toggleAnnotation(layer, false);
           }
         }


### PR DESCRIPTION
Adds the ability to specify via a `?annotations=all` param that all annotations should be displayed.
