### PR TITLE
Update node-odm image to stable version

### DIFF
--- a/docker-compose.nodeodm.yml
+++ b/docker-compose.nodeodm.yml
@@ -10,7 +10,7 @@ services:
     environment:
       - WO_DEFAULT_NODES
   node-odm:
-    image: opendronemap/nodeodm
+    image: opendronemap/nodeodm:stable
     expose:
       - "3000"
     restart: unless-stopped


### PR DESCRIPTION
The current ODM 24.04 update has problems, which are surfacing in threads like https://community.opendronemap.org/t/project-webodm-works-vs-nodeodm-error/25584/2 and https://github.com/OpenDroneMap/ODM/issues/1949

I'm pinning the NodeODM image to a stable (pre 24.04 update) tag until things are more battle tested.