### PR TITLE
Install rasterio 1.3.10.post1 on arm due to missing numpy rc dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -53,7 +53,8 @@ vine==1.3.0
 webcolors==1.5
 https://github.com/OpenDroneMap/WebODM/releases/download/v3.0.0/rio_tiler-2.1.2-morecantile-3.2.0.zip
 rio-color==1.0.4
-rasterio==1.3.10 ; sys_platform == 'linux' or sys_platform == 'darwin'
+rasterio==1.3.10 ; platform_machine == 'x86_64' and (sys_platform == 'linux' or sys_platform == 'darwin')
+https://github.com/OpenDroneMap/WebODM/releases/download/v3.0.0/rasterio-1.3.10.post1.zip ; platform_machine == 'aarch64' and (sys_platform == 'linux' or sys_platform == 'darwin')
 https://github.com/OpenDroneMap/WebODM/releases/download/v1.9.7/rasterio-1.2.10-cp39-cp39-win_amd64.whl ; sys_platform == "win32"
 https://github.com/OpenDroneMap/WebODM/releases/download/v1.9.7/GDAL-3.3.3-cp39-cp39-win_amd64.whl ; sys_platform == "win32"
 Shapely==1.8.0 ; sys_platform == "win32"


### PR DESCRIPTION
Fixing the joys of the Python dependency ecosystem that keeps on giving.