### PR TITLE
Add settings.PLUGINS_CORE_IGNORE_SCRIPTS to workaround an issue under the MSIX PSF

### DIFF
--- a/app/plugins/functions.py
+++ b/app/plugins/functions.py
@@ -93,7 +93,7 @@ def build_plugins():
                 if platform.system() == "Windows":
                     npm = "npm.cmd"
                 command = [npm, 'install']
-                if settings.PLUGINS_CORE_IGNORE_SCRIPTS and plugin.is_persistent():
+                if plugin.is_persistent():
                     command.append('--ignore-scripts')
                 subprocess.call(command, cwd=plugin.get_path("public"))
             except FileNotFoundError:

--- a/webodm/settings.py
+++ b/webodm/settings.py
@@ -79,10 +79,6 @@ PLUGINS_BLACKLIST = [
     #'measure',
 ]
 
-# Do not run npm postinstall scripts when installing coreplugin dependencies,
-# workaround for core-js's postinstall script breaking under the MSIX PSF.
-PLUGINS_CORE_IGNORE_SCRIPTS = False
-
 # Serve media static files URLs even in production
 FORCE_MEDIA_STATICFILES = False
 


### PR DESCRIPTION
When WebODM is packaged in MSIX and the install location is redirected with the file redirection PSF fixup, it is not possible to set the current working directory to be a folder created under the redirection [(source)](https://github.com/microsoft/MSIX-PackageSupportFramework/blob/main/fixups/FileRedirectionFixup/readme.md#changing-directories). `npm` does this when running postinstall scripts. This meant that WebODM failed to initialize some of its core plugins.

Thankfully, the only postinstall script in core plugins appear to be core-js's advertisement script. So we can just add a settings to disable those. User plugins still get their postinstall scripts ran normally, because those are not subject to the PSF.