### PR TITLE
Add ability to notify remote endpoint when quota is being exceeded

### DIFF
--- a/webodm/settings.py
+++ b/webodm/settings.py
@@ -373,6 +373,9 @@ RESET_PASSWORD_LINK = ''
 # from an account that is exceeding a disk quota
 QUOTA_EXCEEDED_GRACE_PERIOD = 8
 
+# URL to call when an account is about to have some of its tasks removed
+QUOTA_EXCEEDED_NOTIFY_URL = None
+
 # Maximum number of processing nodes to show in "Processing Nodes" menus/dropdowns
 UI_MAX_PROCESSING_NODES = None
 


### PR DESCRIPTION
Adds a `QUOTA_EXCEEDED_NOTIFY_URL` configuration item which allows WebODM to notify remote URLs that a user has exceeded its disk quota and that tasks are scheduled for removal.