### PR TITLE
Add platform specific GLB rendering

### DIFF
--- a/app/api/tasks.py
+++ b/app/api/tasks.py
@@ -776,8 +776,13 @@ class TaskSafeTexturedModel(TaskNestedView):
         """
         task = self.get_and_check_task(request, pk)
 
+        platform = request.query_params.get('platform', '')
+        max_size_mb = 120
+        if platform == "mobile":
+            max_size_mb = 60
+
         try:
-            model_file = task.get_safe_textured_model()
+            model_file = task.get_safe_textured_model(max_size_mb=max_size_mb)
             return download_file_response(request, model_file, 'attachment')
         except FileNotFoundError:
             raise exceptions.NotFound(_("Asset does not exist"))

--- a/app/static/app/js/ModelView.jsx
+++ b/app/static/app/js/ModelView.jsx
@@ -6,6 +6,7 @@ import AssetDownloadButtons from './components/AssetDownloadButtons';
 import Standby from './components/Standby';
 import ShareButton from './components/ShareButton';
 import ImagePopup from './components/ImagePopup';
+import Utils from './classes/Utils';
 import PropTypes from 'prop-types';
 import * as THREE from 'THREE';
 import $ from 'jquery';
@@ -300,7 +301,9 @@ class ModelView extends React.Component {
   }
 
   glbFilePath = () => {
-    return this.basePath() + '/textured_model/';
+    let url = this.basePath() + '/textured_model/';
+    if (Utils.isMobile()) url += "?platform=mobile";
+    return url;
   }
 
   mtlFilename = (cb) => {
@@ -682,9 +685,14 @@ class ModelView extends React.Component {
     // Using opacity we can still perform measurements
     viewer.setEDLOpacity(flag ? 1 : 0);
 
-    // for(let pointcloud of viewer.scene.pointclouds){
-    //     pointcloud.visible = flag;
-    // }
+    // On mobile, for performance and because opacity doesn't
+    // seem to work consistently, we remove the ability to do
+    // measurements
+    if (Utils.isMobile()){
+        for(let pointcloud of viewer.scene.pointclouds){
+            pointcloud.visible = flag;
+        }
+    }
   }
 
   toggleCameras = (e) => {


### PR DESCRIPTION
Mobile browsers have lower memory limits in terms of rendering large 3D models. So I generate different GLBs depending on the target platform.

Also bumps down the desktop limit to 120mb which seems safer. 