### PR TITLE
iOS point budget and textured model tweaks

### DIFF
--- a/app/api/tasks.py
+++ b/app/api/tasks.py
@@ -780,6 +780,8 @@ class TaskSafeTexturedModel(TaskNestedView):
         max_size_mb = 120
         if platform == "mobile":
             max_size_mb = 60
+        elif platform == "ios":
+            max_size_mb = 5
 
         try:
             model_file = task.get_safe_textured_model(max_size_mb=max_size_mb)

--- a/app/static/app/js/ModelView.jsx
+++ b/app/static/app/js/ModelView.jsx
@@ -302,7 +302,10 @@ class ModelView extends React.Component {
 
   glbFilePath = () => {
     let url = this.basePath() + '/textured_model/';
-    if (Utils.isMobile()) url += "?platform=mobile";
+    
+    if (Utils.isIOS()) url += "?platform=ios";
+    else if (Utils.isMobile()) url += "?platform=mobile";
+    
     return url;
   }
 
@@ -341,7 +344,10 @@ class ModelView extends React.Component {
     window.viewer = new Potree.Viewer(container);
     viewer.setEDLEnabled(true);
     viewer.setFOV(60);
-    if (Utils.isMobile()){
+
+    if (Utils.isIOS()){
+        viewer.setPointBudget(1000*1000);
+    }else if (Utils.isMobile()){
         viewer.setPointBudget(2*1000*1000);
     }else{
         viewer.setPointBudget(10*1000*1000);

--- a/app/static/app/js/classes/Utils.js
+++ b/app/static/app/js/classes/Utils.js
@@ -123,7 +123,11 @@ export default {
     },
 
     isMobile: function(){
-      return navigator.userAgent.match(/(iPad)|(iPhone)|(iPod)|(android)|(webOS)/i);
+      return navigator.userAgent.match(/(android)|(webOS)/i) || this.isIOS();
+    },
+
+    isIOS: function(){
+      return navigator.userAgent.match(/(iPad)|(iPhone)|(iPod)/i) || (navigator.userAgent.match(/Mac/i) && "ontouchend" in document);
     },
 
     userInputToFilename(text, extension = ""){


### PR DESCRIPTION
iOS, especially older versions, have trouble loading lots of assets in GPU memory, causing the viewer to crash.

This PR improves the point budget allocation as well as the textured model compression size.