### PR TITLE
Fix sharp pixel limit crash for large textures

### DIFF
--- a/app/scripts/glbopti.js
+++ b/app/scripts/glbopti.js
@@ -97,7 +97,7 @@ async function main() {
                 encoder,
                 resize: [textureSize, textureSize],
                 targetFormat: undefined,
-                limitInputPixels: true,
+                limitInputPixels: false,
         }),
         draco({
             quantizationVolume: "scene"


### PR DESCRIPTION
### What changed
- Disabled Sharp input pixel limit to prevent crashes on large textures

### Why
Sharp throws `Input image exceeds pixel limit` when processing large images,
causing GLB generation to fail.

### Result
Allows large textures to be processed without crashing the pipeline.
<img width="489" height="228" alt="Screenshot 2025-12-31 084849" src="https://github.com/user-attachments/assets/e7748c8b-1257-4bfc-8c55-db21fcf2d93a" />
