### PR TITLE
formulas: add BGRNReP and RGBNReP as used by the Micasense Rededge-P

### DIFF
--- a/app/api/formulas.py
+++ b/app/api/formulas.py
@@ -152,6 +152,8 @@ camera_filters = [
     'BGRNReL',
     'BGRReNL',
 
+    'BGRNReP',
+    'RGBNReP',
     'RGBNRePL',
 
     'L', # FLIR camera has a single LWIR band

--- a/app/tests/test_formulas.py
+++ b/app/tests/test_formulas.py
@@ -49,31 +49,42 @@ class TestFormulas(TestCase):
             for f in i['filters']:
                 bands = list(set(re.findall(pattern, f)))
                 self.assertTrue(len(bands) <= 5)
-    
+
     def test_auto_bands(self):
         obands = [{'name': 'red', 'description': 'red'},
                  {'name': 'green', 'description': 'green'},
                  {'name': 'blue', 'description': 'blue'},
                  {'name': 'gray', 'description': 'nir'},
                  {'name': 'alpha', 'description': None}]
-        
+
         self.assertEqual(get_auto_bands(obands, "NDVI")[0], "RGBN")
         self.assertTrue(get_auto_bands(obands, "NDVI")[1])
-        
+
         self.assertEqual(get_auto_bands(obands, "Celsius")[0], "L")
         self.assertFalse(get_auto_bands(obands, "Celsius")[1])
 
         self.assertEqual(get_auto_bands(obands, "VARI")[0], "RGBN")
         self.assertTrue(get_auto_bands(obands, "VARI")[0])
-        
+
         obands = [{'name': 'red', 'description': None},
                  {'name': 'green', 'description': None},
                  {'name': 'blue', 'description': None},
                  {'name': 'gray', 'description': None},
                  {'name': 'alpha', 'description': None}]
-        
+
         self.assertEqual(get_auto_bands(obands, "NDVI")[0], "RGN")
         self.assertFalse(get_auto_bands(obands, "NDVI")[1])
-        
+
         self.assertEqual(get_auto_bands(obands, "VARI")[0], "RGB")
         self.assertFalse(get_auto_bands(obands, "VARI")[1])
+
+        obands = [{'name': 'red', 'description': 'red'},
+            {'name': 'green', 'description': 'green'},
+            {'name': 'blue', 'description': 'blue'},
+            {'name': 'gray', 'description': 'nir'},
+            {'name': 'rededge', 'description': 're'},
+            {'name': 'panchro', 'description': 'panchro'},
+            {'name': 'alpha', 'description': None}]
+
+        self.assertEqual(get_auto_bands(obands, "NDVI")[0], "RGBNReP")
+        self.assertTrue(get_auto_bands(obands, "NDVI")[1])


### PR DESCRIPTION
With automatic camera filters, the fallback for NDVI is "RGN" (the first one which contains all bands needed for the calculation). This produces wrong results if the band is not set automatically.

So for the Micasense RedEdge-P, the bands are "BGRNReP" which is currently missing.

Adding this helps to automatically select the camera bands correctly.

fixes #1840 

Dataset for reproduction of the issue:
https://fh-aachen.sciebo.de/s/qMxs3jHH4FKb2S5