### PR TITLE
Fix bash paths to allow usage on NixOS

### DIFF
--- a/dev-worker.sh
+++ b/dev-worker.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Launch a development worker so that changes in a dev
 # environment can be refreshed
 

--- a/devenv.sh
+++ b/devenv.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 echo "devenv.sh is deprecated! Use \"./webodm.sh start --dev\" instead."

--- a/run_tests_in_docker.sh
+++ b/run_tests_in_docker.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 export COMPOSE_FILE=docker-compose.yml:docker-compose.build.yml
 WAIT_SECONDS=20

--- a/webodm.sh
+++ b/webodm.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eo pipefail
 __dirname=$(cd "$(dirname "$0")"; pwd -P)
 cd "${__dirname}"


### PR DESCRIPTION
This addresses #1853 if that change is desired.

Note: The contribution guidelines note that I should provide this warning - AI was used in the development of the issue and subsequently this PR, however I was able to confirm that the fix/workaround command was able to create a working WebODM installation in Docker, and I believe that the changes shown below are correct. Please feel free to confirm in your own test environments, and I can provide a hand-tailored NixOS `configuration.nix` for testing if you would like to test it in a virtual machine for the verification of this PR. I've run it on my local NixOS box to my satisfaction, and already have nodes processing data and providing results.

I don't particularly mind if this PR is rejected as I've already mitigated the issue locally; I'm submitting this purely for the benefit of the next NixOS user to come along this project.