### PR TITLE
Fix import of .tiff files

### DIFF
--- a/app/api/tasks.py
+++ b/app/api/tasks.py
@@ -835,13 +835,16 @@ class TaskExternalImportUpload(APIView):
         if asset_file_candidates is None: 
             raise exceptions.ValidationError(detail=_("Invalid file type"))
 
+        ext_aliases = {
+            '.tiff': '.tif'
+        }
         for f in asset_file_candidates:
-            if os.path.splitext(f)[1].lower() == file_ext.lower():
+            if os.path.splitext(f)[1].lower() == ext_aliases.get(file_ext.lower(), file_ext.lower()):
                 asset_file = f
                 break
 
         if asset_file is None:
-            raise exceptions.ValidationError(detail=_("Invalid file type"))
+            raise exceptions.ValidationError(detail=_("Invalid file type (extension mismatch)"))
 
         chunk_index = request.data.get('dzchunkindex')
         uuid = request.data.get('dzuuid') 

--- a/app/raster_utils.py
+++ b/app/raster_utils.py
@@ -245,6 +245,9 @@ def export_raster(input, output, progress_callback=None, **opts):
                                 ci.index(ColorInterp.green) + 1,
                                 ci.index(ColorInterp.blue) + 1,
                                 ci.index(ColorInterp.alpha) + 1)
+                # No? pick first three + alpha
+                elif ColorInterp.alpha in ci:
+                    indexes = (1, 2, 3, ci.index(ColorInterp.alpha) + 1)
             
             # Only 2 bands (common with thermal)?
             elif len(ci) == 2 and ColorInterp.gray in ci and ColorInterp.alpha in ci:


### PR DESCRIPTION
Comparison of .tif => .tiff leads to an import error for external assets.