### PR TITLE
Always use UTC

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -47,7 +47,6 @@ rjsmin==1.0.12
 simplejson==3.10.0
 six==1.11.0
 strict-rfc3339==0.7
-tzlocal==1.3
 uritemplate==3.0.0
 vine==1.3.0
 webcolors==1.5

--- a/webodm/settings.py
+++ b/webodm/settings.py
@@ -165,7 +165,7 @@ AUTHENTICATION_BACKENDS = (
 # https://docs.djangoproject.com/en/1.10/topics/i18n/
 
 LANGUAGE_CODE = 'en-us'
-TIME_ZONE = 'UTC'
+TIME_ZONE = 'Etc/UTC'
 USE_I18N = True
 USE_L10N = True
 USE_TZ = True

--- a/webodm/settings.py
+++ b/webodm/settings.py
@@ -2,7 +2,6 @@ import os, sys, json
 
 import datetime
 
-import tzlocal
 from django.contrib.messages import constants as messages
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
@@ -166,7 +165,7 @@ AUTHENTICATION_BACKENDS = (
 # https://docs.djangoproject.com/en/1.10/topics/i18n/
 
 LANGUAGE_CODE = 'en-us'
-TIME_ZONE = tzlocal.get_localzone().zone
+TIME_ZONE = 'UTC'
 USE_I18N = True
 USE_L10N = True
 USE_TZ = True


### PR DESCRIPTION
We don't use any of Django's templating, so timezone settings can be safely defaulted to UTC.