### PR TITLE
Always show share button even in desktop mode

### DIFF
--- a/app/views/app.py
+++ b/app/views/app.py
@@ -93,7 +93,7 @@ def map(request, project_pk=None, task_pk=None):
                 'map-items': json.dumps(mapItems),
                 'title': title,
                 'public': 'false',
-                'share-buttons': 'false' if settings.DESKTOP_MODE else 'true',
+                'share-buttons': 'true',
                 'permissions': json.dumps(get_permissions(request.user, project)),
                 'project': json.dumps(projectInfo),
                 'basemaps': json.dumps(Basemap.get_cached_basemaps()),
@@ -122,7 +122,7 @@ def model_display(request, project_pk=None, task_pk=None):
             'params': {
                 'task': json.dumps(task.get_model_display_params()),
                 'public': 'false',
-                'share-buttons': 'false' if settings.DESKTOP_MODE else 'true'
+                'share-buttons': 'true'
             }.items()
         })
 

--- a/app/views/public.py
+++ b/app/views/public.py
@@ -54,7 +54,7 @@ def handle_map(request, template, uuid_type=None, uuid=None, hide_title=False):
             'title': title if not hide_title else '',
             'public': 'true',
             'public-edit': str(public_edit).lower(),
-            'share-buttons': 'false' if settings.DESKTOP_MODE else 'true',
+            'share-buttons': 'true',
             'selected-map-type': request.GET.get('t', 'auto'),
             'permissions': json.dumps(permissions),
             'project': json.dumps(projectInfo),
@@ -81,7 +81,7 @@ def handle_model_display(request, template, task_pk=None):
                 'task': json.dumps(task.get_model_display_params()),
                 'public': 'true',
                 'public-edit': str(task.public_edit).lower(),
-                'share-buttons': 'false' if settings.DESKTOP_MODE else 'true',
+                'share-buttons': 'true',
                 'model-type': request.GET.get('t', 'cloud'),
             }.items()
         })


### PR DESCRIPTION
It can be useful to share on a desktop instance, for example for giving QGIS access to the map tiles. There's already a warning in place saying that private links are not visible to the outside.