### PR TITLE
JOSM plugin title in url and in JOSM desktop (issue #1945)

### DIFF
--- a/coreplugins/osm-quickedit/public/main.js
+++ b/coreplugins/osm-quickedit/public/main.js
@@ -99,8 +99,9 @@ PluginsAPI.Map.addActionButton(function (options) {
         }
 
         function prepareJOSM() {
+          var taskTitle = tile.meta.task.name || tile.meta.task.id;
           var imageryParams = {
-            title: tile.meta.name,
+            title: encodeURIComponent(taskTitle),
             type: "tms",
             max_zoom: 24,
             url: encodeURIComponent(tileUrl),
@@ -118,7 +119,7 @@ PluginsAPI.Map.addActionButton(function (options) {
             right: options.map.getBounds().getEast(),
             top: options.map.getBounds().getNorth(),
             changeset_comment: "",
-            changeset_source: encodeURIComponent("WebODM - " + tile.meta.name),
+            changeset_source: encodeURIComponent("WebODM - " + taskTitle),
             new_layer: false,
           };
           sendJOSMCmd("http://127.0.0.1:8111/load_and_zoom", loadAndZoomParams);


### PR DESCRIPTION
Fixes #1945 

Sets the `title` and `changeset_source` correctly with the task's title or with the task's ID if it lacks a title (i.e - an orthophoto that was made directly through ODM/ODX) using the existing `encodeURIComponent`.

Tested with JOSM 19555 on Windows 11 with the [brighton_beach](https://github.com/pierotofy/drone_dataset_brighton_beach) dataset.