### PR TITLE
Fix Share to DroneDB silently doing nothing

### DIFF
--- a/coreplugins/dronedb/api_views.py
+++ b/coreplugins/dronedb/api_views.py
@@ -394,11 +394,11 @@ class ShareTaskView(TaskView):
 def share_to_ddb(pk, settings, files, tag=None, org_slug=None, dataset_name=None):
     import os, time
     from app.plugins import logger
-    from app.plugins import get_current_plugin
+    from app.plugins.functions import get_plugin_by_name
     from coreplugins.dronedb.ddb import DroneDB
 
     status_key = '{}_ddb'.format(pk)
-    datastore = get_current_plugin().get_global_data_store()
+    datastore = get_plugin_by_name('dronedb').get_global_data_store()
 
     registry_url, username, password, token = settings
 

--- a/coreplugins/dronedb/api_views.py
+++ b/coreplugins/dronedb/api_views.py
@@ -24,8 +24,8 @@ from rest_framework import status
 
 VALID_IMAGE_EXTENSIONS = ['.tiff', '.tif', '.png', '.jpeg', '.jpg']
 
-# Regex pattern for valid tag format: "org" or "org/dataset" with lowercase alphanumeric and hyphens
-TAG_PATTERN = re.compile(r'^[a-z0-9][a-z0-9\-]*(/[a-z0-9][a-z0-9\-]*)?$')
+# Regex pattern for valid tag format: "org/dataset" with lowercase alphanumeric and hyphens (both parts required)
+TAG_PATTERN = re.compile(r'^[a-z0-9][a-z0-9\-]*/[a-z0-9][a-z0-9\-]*$')
 
 def is_valid(file):
     _, file_extension = path.splitext(file)
@@ -336,9 +336,13 @@ class ShareTaskView(TaskView):
         org_slug = request.data.get('orgSlug', None)
         dataset_name = request.data.get('datasetName', None) or task.name
 
+        # Normalize blank tag to None
+        if tag is not None:
+            tag = tag.strip() or None
+
         # Validate tag format if provided (must be "org/dataset")
-        if tag is not None and tag.strip():
-            tag = tag.strip().lower()
+        if tag is not None:
+            tag = tag.lower()
             if not TAG_PATTERN.match(tag):
                 return Response({
                     'error': 'Invalid tag format. Must be "org/dataset" with lowercase alphanumeric characters and hyphens only.'
@@ -441,7 +445,7 @@ def share_to_ddb(pk, settings, files, tag=None, org_slug=None, dataset_name=None
                 except Exception as e:
 
                     if (attempt == 3):
-                        raise
+                        raise Exception("Failed to upload file {}: {}".format(file['name'], str(e))) from e
                     else:
                         logger.info("Error uploading file {}: {}. Retrying...".format(file['name'], str(e)))
                         time.sleep(5)

--- a/coreplugins/dronedb/api_views.py
+++ b/coreplugins/dronedb/api_views.py
@@ -11,7 +11,7 @@ from os import listdir, path
 from app import models, pending_actions
 from app.security import path_traversal_check
 from app.plugins.views import TaskView
-from app.plugins.worker import run_function_async, task
+from app.plugins.worker import run_function_async
 from app.plugins import get_current_plugin
 from app.plugins import GlobalDataStore, get_site_settings, signals as plugin_signals
 
@@ -19,7 +19,6 @@ from coreplugins.dronedb.ddb import DEFAULT_HUB_URL, DroneDB, parse_url, verify_
 
 from django.dispatch import receiver
 
-from worker.celery import app
 from rest_framework.response import Response
 from rest_framework import status
 
@@ -332,17 +331,28 @@ class ShareTaskView(TaskView):
 
         task = self.get_and_check_task(request, pk)
 
-        # Get optional tag and datasetName from request
+        # Get optional tag, orgSlug and datasetName from request
         tag = request.data.get('tag', None)
+        org_slug = request.data.get('orgSlug', None)
         dataset_name = request.data.get('datasetName', None) or task.name
 
-        # Validate tag format if provided
+        # Validate tag format if provided (must be "org/dataset")
         if tag is not None and tag.strip():
             tag = tag.strip().lower()
             if not TAG_PATTERN.match(tag):
                 return Response({
-                    'error': 'Invalid tag format. Must be "org" or "org/dataset" with lowercase alphanumeric characters and hyphens only.'
+                    'error': 'Invalid tag format. Must be "org/dataset" with lowercase alphanumeric characters and hyphens only.'
                 }, status=status.HTTP_400_BAD_REQUEST)
+
+        # Validate orgSlug if provided
+        if org_slug is not None and org_slug.strip():
+            org_slug = org_slug.strip().lower()
+            if not re.match(r'^[a-z0-9][a-z0-9\-]*$', org_slug):
+                return Response({
+                    'error': 'Invalid org slug format.'
+                }, status=status.HTTP_400_BAD_REQUEST)
+        else:
+            org_slug = None
 
         # Sanitize dataset_name (remove potentially dangerous characters)
         if dataset_name:
@@ -376,78 +386,78 @@ class ShareTaskView(TaskView):
 
         files = [{'path': f, 'name': f[len(assets_path)+1:], 'size': os.path.getsize(f)} for f in available_assets]
 
-        share_to_ddb.delay(pk, settings, files, tag, dataset_name)
+        run_function_async(share_to_ddb, pk, settings, files, tag, org_slug, dataset_name)
 
         return Response(data, status=status.HTTP_200_OK)
 
 
-@task
-def share_to_ddb(pk, settings, files, tag=None, dataset_name=None):
-
+def share_to_ddb(pk, settings, files, tag=None, org_slug=None, dataset_name=None):
+    import os, time
     from app.plugins import logger
+    from app.plugins import get_current_plugin
+    from coreplugins.dronedb.ddb import DroneDB
 
-    status_key = get_status_key(pk)
+    status_key = '{}_ddb'.format(pk)
     datastore = get_current_plugin().get_global_data_store()
 
     registry_url, username, password, token = settings
 
     ddb = DroneDB(registry_url, username, password, token)
 
-    # Init share with optional tag and dataset name
-    share_token = ddb.share_init(tag=tag, dataset_name=dataset_name)
-
     status = datastore.get_json(status_key)
-
     status['totalFiles'] = len(files)
     status['totalSize'] = sum(i['size'] for i in files)
-
     datastore.set_json(status_key, status)
 
-    for file in files:
+    try:
+        # Init share with optional tag, orgSlug and dataset name
+        share_token = ddb.share_init(tag=tag, org_slug=org_slug, dataset_name=dataset_name)
 
-        # check that file exists
-        if not os.path.exists(file['path']):
-            logger.info("File {} does not exist".format(file['path']))
-            continue
+        for file in files:
 
-        attempt = 0
+            # check that file exists
+            if not os.path.exists(file['path']):
+                logger.info("File {} does not exist".format(file['path']))
+                continue
 
-        while attempt < 3:
-            try:
+            attempt = 0
 
-                attempt += 1
+            while attempt < 3:
+                try:
 
-                up = ddb.share_upload(share_token, file['path'], file['name'])
+                    attempt += 1
 
-                logger.info("Uploaded " + file['name'] + " to Dronedb (hash: " + up['hash'] + ")")
+                    up = ddb.share_upload(share_token, file['path'], file['name'])
 
-                status['uploadedFiles'] += 1
-                status['uploadedSize'] += file['size']
+                    logger.info("Uploaded " + file['name'] + " to Dronedb (hash: " + up['hash'] + ")")
 
-                datastore.set_json(status_key, status)
+                    status['uploadedFiles'] += 1
+                    status['uploadedSize'] += file['size']
 
-                break
-
-            except Exception as e:
-
-                if (attempt == 3):
-                    logger.error("Error uploading file {}: {}".format(file['name'], str(e)))
-                    status['error'] = "Error uploading file {}: {}".format(file['name'], str(e))
-                    status['status'] = 2 # Error
                     datastore.set_json(status_key, status)
-                    return
-                else:
-                    logger.info("Error uploading file {}: {}. Retrying...".format(file['name'], str(e)))
-                    time.sleep(5)
-                    continue
 
+                    break
 
-    res = ddb.share_commit(share_token)
+                except Exception as e:
 
-    status['status'] = 3 # Done
-    status['shareUrl'] = registry_url + res['url']
+                    if (attempt == 3):
+                        raise
+                    else:
+                        logger.info("Error uploading file {}: {}. Retrying...".format(file['name'], str(e)))
+                        time.sleep(5)
+                        continue
 
-    logger.info("Shared on url " + status['shareUrl'])
+        res = ddb.share_commit(share_token)
+
+        status['status'] = 3  # Done
+        status['shareUrl'] = registry_url + res['url']
+
+        logger.info("Shared on url " + status['shareUrl'])
+
+    except Exception as e:
+        logger.error("Error sharing to DroneDB: {}".format(str(e)))
+        status['status'] = 2  # Error
+        status['error'] = str(e)
 
     datastore.set_json(status_key, status)
 

--- a/coreplugins/dronedb/ddb.py
+++ b/coreplugins/dronedb/ddb.py
@@ -193,12 +193,14 @@ class DroneDB:
         except Exception as e:
             raise Exception("Failed to get files list.") from e
 
-    def share_init(self, tag=None, dataset_name=None):
+    def share_init(self, tag=None, org_slug=None, dataset_name=None):
         try:
 
             data = {}
             if tag is not None:
                 data['tag'] = tag
+            if org_slug is not None:
+                data['orgSlug'] = org_slug
             if dataset_name is not None:
                 data['datasetName'] = dataset_name
 

--- a/coreplugins/dronedb/ddb.py
+++ b/coreplugins/dronedb/ddb.py
@@ -155,13 +155,30 @@ class DroneDB:
     def get_folders(self, orgSlug, dsSlug):
 
         try:
+            import posixpath
 
-            # Type 1 is folder
-            payload = {'query': '*', 'recursive': True, 'type': 1}
+            # Search all entries recursively (no type filter)
+            payload = {'query': '*', 'recursive': True}
 
             response = self.wrapped_call('POST', self.__get_folders_url.format(orgSlug, dsSlug), data=payload)
 
-            return [o['path'] for o in response.json()]
+            entries = response.json()
+            dirs = set()
+
+            for o in entries:
+                path = o.get('path', '')
+                entry_type = o.get('type', 0)
+
+                # Include explicit Directory entries (type=1)
+                if entry_type == 1 and path:
+                    dirs.add(path)
+                else:
+                    # Infer parent directory from file path
+                    parent = posixpath.dirname(path)
+                    if parent and parent != '.':
+                        dirs.add(parent)
+
+            return sorted(dirs)
 
         except Exception as e:
             raise Exception("Failed to get folders.") from e

--- a/coreplugins/dronedb/ddb.py
+++ b/coreplugins/dronedb/ddb.py
@@ -173,10 +173,12 @@ class DroneDB:
                 if entry_type == 1 and path:
                     dirs.add(path)
                 else:
-                    # Infer parent directory from file path
-                    parent = posixpath.dirname(path)
-                    if parent and parent != '.':
-                        dirs.add(parent)
+                    # Infer all ancestor directories from file path
+                    parts = path.split('/')
+                    for i in range(1, len(parts)):
+                        ancestor = '/'.join(parts[:i])
+                        if ancestor and ancestor != '.':
+                            dirs.add(ancestor)
 
             return sorted(dirs)
 

--- a/coreplugins/dronedb/public/ShareButton.jsx
+++ b/coreplugins/dronedb/public/ShareButton.jsx
@@ -104,14 +104,14 @@ export default class ShareButton extends React.Component {
 
     shareToDdb = (options = {}) => {
         const { task } = this.props;
-        const { tag, datasetName } = options;
+        const { tag, orgSlug, datasetName } = options;
 
         this.setState({ showDialog: false });
 
         return $.ajax({
             url: `/api/plugins/dronedb/tasks/${task.id}/share`,
             contentType: 'application/json',
-            data: JSON.stringify({ tag, datasetName }),
+            data: JSON.stringify({ tag, orgSlug, datasetName }),
             dataType: 'json',
             type: 'POST'
         }).done(taskInfo => {

--- a/coreplugins/dronedb/public/components/ShareDialog.jsx
+++ b/coreplugins/dronedb/public/components/ShareDialog.jsx
@@ -192,22 +192,22 @@ export default class ShareDialog extends Component {
         const { shareMode, selectedOrganization, selectedDataset, newDatasetName, createNewDataset } = this.state;
 
         let tag = null;
+        let orgSlug = null;
         let datasetName = null;
 
         if (shareMode === SHARE_MODE_SELECT && selectedOrganization) {
             if (createNewDataset) {
-                // Will create new dataset in selected org
-                // tag format: "org/" means create new dataset in org
-                tag = selectedOrganization.value;
+                // Will create new dataset in selected org — send orgSlug separately, not as tag
+                orgSlug = selectedOrganization.value;
                 datasetName = newDatasetName || this.props.taskName || null;
             } else if (selectedDataset && selectedDataset.value !== '__new__') {
-                // Use existing dataset
+                // Use existing dataset — send as "org/dataset" tag
                 tag = `${selectedOrganization.value}/${selectedDataset.value}`;
             }
         }
-        // If SHARE_MODE_QUICK, tag remains null (backend creates personal org + random dataset)
+        // If SHARE_MODE_QUICK, both tag and orgSlug remain null (backend creates personal org + random dataset)
 
-        this.props.onShare({ tag, datasetName });
+        this.props.onShare({ tag, orgSlug, datasetName });
     };
 
     getTotalSize() {


### PR DESCRIPTION
Three bugs prevented the Share button from uploading anything:

1. share_to_ddb was decorated with @task (raw Celery), but the worker process only loads 'worker.tasks' and 'app.plugins.worker'. The task was never registered in the worker, so messages were silently discarded. Switch to run_function_async() like every other plugin (objdetect, contours, measure, cesiumion).

2. When the user chose 'Create new dataset in org X', ShareDialog sent tag='orgslug' (no slash). Registry's ToTag() requires exactly 'org/dataset' and threw FormatException -> HTTP 400. Fix: send orgSlug as a separate form field instead of abusing the tag field.

3. share_init() and share_commit() were called outside any try/except. Any exception left status=1 (Running) forever in the datastore, so the frontend polled endlessly showing 'Sharing'. Wrap the entire upload flow in a try/except that sets status=2 (Error) on failure.