### PR TITLE
Add SWISSIMAGE overzoom and EPSG:2056 support to the GCP Interface

### DIFF
--- a/app/management/commands/basemaps.py
+++ b/app/management/commands/basemaps.py
@@ -31,6 +31,14 @@ DEFAULT_BASEMAPS = [
         'maxzoom': 19,
         'minzoom': 0,
     },
+    {
+        'type': 'tms',
+        'url': 'https://wmts.geo.admin.ch/1.0.0/ch.swisstopo.swissimage/default/current/3857/{z}/{x}/{y}.jpeg',
+        'attribution': '&copy; swisstopo',
+        'label': 'SWISSIMAGE (swisstopo)',
+        'maxzoom': 20,
+        'minzoom': 0,
+    },
 ]
 
 

--- a/app/migrations/0052_add_swissimage_basemap.py
+++ b/app/migrations/0052_add_swissimage_basemap.py
@@ -1,0 +1,38 @@
+from django.db import migrations
+from django.core.cache import cache
+
+
+SWISSIMAGE = {
+    'type': 'tms',
+    'url': 'https://wmts.geo.admin.ch/1.0.0/ch.swisstopo.swissimage/default/current/3857/{z}/{x}/{y}.jpeg',
+    'attribution': '&copy; swisstopo',
+    'label': 'SWISSIMAGE (swisstopo)',
+    'maxzoom': 20,
+    'minzoom': 0,
+}
+
+
+def add_swissimage(apps, schema_editor):
+    Basemap = apps.get_model('app', 'Basemap')
+    Basemap.objects.get_or_create(label=SWISSIMAGE['label'], defaults=SWISSIMAGE)
+    cache.delete('app_basemaps')
+
+
+def remove_swissimage(apps, schema_editor):
+    Basemap = apps.get_model('app', 'Basemap')
+    Basemap.objects.filter(
+        label=SWISSIMAGE['label'],
+        url=SWISSIMAGE['url'],
+    ).delete()
+    cache.delete('app_basemaps')
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('app', '0051_init_basemaps'),
+    ]
+
+    operations = [
+        migrations.RunPython(add_swissimage, remove_swissimage),
+    ]

--- a/app/tests/test_basemap.py
+++ b/app/tests/test_basemap.py
@@ -13,8 +13,11 @@ class TestBasemap(BootTestCase):
         pass
 
     def test_basemap(self):
-        # There should be 3 basemaps by default
-        self.assertEqual(Basemap.objects.all().count(), 3)
+        # There should be 4 basemaps by default
+        self.assertEqual(Basemap.objects.all().count(), 4)
+        self.assertTrue(
+            Basemap.objects.filter(label='SWISSIMAGE (swisstopo)').exists()
+        )
 
         Basemap.objects.all().delete()
         Basemap.invalidate_cache()
@@ -96,4 +99,3 @@ class TestBasemap(BootTestCase):
         client.login(username='testsuperuser', password='test1234')
         response = client.get('/admin/app/basemap/')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-

--- a/app/tests/test_gcpi_integration.py
+++ b/app/tests/test_gcpi_integration.py
@@ -1,0 +1,19 @@
+from django.test import Client
+from rest_framework import status
+
+from app.models import Basemap
+from .classes import BootTestCase
+
+
+class TestGcpiIntegration(BootTestCase):
+    def test_gcpi_receives_admin_basemaps(self):
+        Basemap.invalidate_cache()
+        client = Client()
+        self.assertTrue(client.login(username='testuser', password='test1234'))
+
+        response = client.get('/plugins/posm-gcpi/')
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertContains(response, 'window.__webodmGcpiConfig')
+        self.assertContains(response, 'swisstopo')
+        self.assertContains(response, 'Ground Control Point Interface')

--- a/coreplugins/posm-gcpi/manifest.json
+++ b/coreplugins/posm-gcpi/manifest.json
@@ -1,8 +1,8 @@
 {
 	"name": "POSM GCP Interface",
 	"webodmMinVersion": "0.5.0",
-	"description": "A plugin to create GCP files from images",
-	"version": "0.4.0",
+	"description": "Create GCP files using WebODM basemaps and optional swisstopo altitude validation",
+	"version": "0.5.0",
 	"author": "Eric Brelsford, Piero Toffanin",
 	"email": "pt@masseranolabs.com",
 	"repository": "https://github.com/WebODM/WebODM",

--- a/coreplugins/posm-gcpi/plugin.py
+++ b/coreplugins/posm-gcpi/plugin.py
@@ -1,3 +1,6 @@
+import json
+
+from app.models import Basemap
 from app.plugins import PluginBase, Menu, MountPoint
 from django.shortcuts import render
 from django.utils.translation import gettext as _
@@ -11,10 +14,14 @@ class Plugin(PluginBase):
     def app_mount_points(self):
         @login_required
         def gcpi(request):
-            return render(request, self.template_path("app.html"), {'title': 'GCP Editor'})
+            return render(request, self.template_path("app.html"), {
+                'title': 'GCP Editor',
+                'gcpi_config': json.dumps({
+                    'basemaps': Basemap.get_cached_basemaps(),
+                }),
+            })
 
         return [
             MountPoint('$', gcpi)
         ]
-
 

--- a/coreplugins/posm-gcpi/templates/app.html
+++ b/coreplugins/posm-gcpi/templates/app.html
@@ -1,5 +1,13 @@
 {% extends "app/plugins/templates/base.html" %}
 
 {% block content %}
-    <iframe src="node_modules/webodm-posm-gcpi/index.html" style="border: none; display: block; min-height: 420px; width: 100%;" class="full-height"></iframe>
+    <script>
+        window.__webodmGcpiConfig = JSON.parse('{{ gcpi_config|escapejs }}');
+    </script>
+    <iframe
+        src="node_modules/webodm-posm-gcpi/index.html"
+        title="Ground Control Point Interface"
+        style="border: none; display: block; min-height: 420px; width: 100%;"
+        class="full-height"
+    ></iframe>
 {% endblock %}

--- a/custom/swisstopo/Dockerfile
+++ b/custom/swisstopo/Dockerfile
@@ -1,0 +1,7 @@
+ARG WEBODM_BASE_IMAGE=webodm/webodm_webapp
+FROM ${WEBODM_BASE_IMAGE}
+
+COPY custom/swisstopo/patch-swisstopo.js \
+  /webodm/coreplugins/posm-gcpi/public/patch-swisstopo.js
+
+RUN node /webodm/coreplugins/posm-gcpi/public/patch-swisstopo.js

--- a/custom/swisstopo/Dockerfile
+++ b/custom/swisstopo/Dockerfile
@@ -1,7 +1,6 @@
 ARG WEBODM_BASE_IMAGE=webodm/webodm_webapp
 FROM ${WEBODM_BASE_IMAGE}
 
-COPY custom/swisstopo/patch-swisstopo.js \
-  /webodm/coreplugins/posm-gcpi/public/patch-swisstopo.js
+COPY patch-swisstopo.js /webodm/coreplugins/posm-gcpi/public/patch-swisstopo.js
 
 RUN node /webodm/coreplugins/posm-gcpi/public/patch-swisstopo.js

--- a/custom/swisstopo/Dockerfile
+++ b/custom/swisstopo/Dockerfile
@@ -1,6 +1,13 @@
 ARG WEBODM_BASE_IMAGE=webodm/webodm_webapp
 FROM ${WEBODM_BASE_IMAGE}
 
-COPY patch-swisstopo.js /webodm/coreplugins/posm-gcpi/public/patch-swisstopo.js
+COPY custom/swisstopo/patch-swisstopo.js /webodm/coreplugins/posm-gcpi/public/patch-swisstopo.js
+COPY coreplugins/posm-gcpi/plugin.py /webodm/coreplugins/posm-gcpi/plugin.py
+COPY coreplugins/posm-gcpi/manifest.json /webodm/coreplugins/posm-gcpi/manifest.json
+COPY coreplugins/posm-gcpi/templates/app.html /webodm/coreplugins/posm-gcpi/templates/app.html
+COPY app/management/commands/basemaps.py /webodm/app/management/commands/basemaps.py
+COPY app/migrations/0052_add_swissimage_basemap.py /webodm/app/migrations/0052_add_swissimage_basemap.py
+COPY app/tests/test_basemap.py /webodm/app/tests/test_basemap.py
+COPY app/tests/test_gcpi_integration.py /webodm/app/tests/test_gcpi_integration.py
 
 RUN node /webodm/coreplugins/posm-gcpi/public/patch-swisstopo.js

--- a/custom/swisstopo/README.md
+++ b/custom/swisstopo/README.md
@@ -1,8 +1,12 @@
 # Swiss additions for the GCP Interface
 
-This overlay adds the swisstopo SWISSIMAGE WMTS provider to the WebODM GCP
-Interface. Native tiles are requested through zoom level 20 and Leaflet
-overzooms the imagery through level 28.
+This overlay connects the GCP Interface to the basemaps managed by WebODM at
+`/admin/app/basemap/`. TMS and WMS entries, the configured default basemap,
+zoom levels, attribution, subdomains and WMS options are passed to the GCP map.
+Leaflet overzooms imagery through level 28.
+
+SWISSIMAGE is installed as a normal WebODM basemap by migration, so it can be
+edited, disabled by deletion, or selected as the default from the admin.
 
 It also registers the Swiss LV95 coordinate reference system with the bundled
 Proj4 library. Existing GCP files can use `EPSG:2056` on their first line:
@@ -12,7 +16,8 @@ EPSG:2056
 2600000 1200000 500 1024 768 image.jpg
 ```
 
-The map provider panel includes a checkbox to compare an existing GCP altitude
+The existing `posm-gcpi` plugin, managed at `/admin/app/plugin/`, includes a
+checkbox to compare an existing GCP altitude
 with the official swisstopo terrain height whenever its marker is selected.
 The comparison is enabled by default. If the returned height differs by more
 than 0.1 metre, the user can confirm replacing the GCP altitude.

--- a/custom/swisstopo/README.md
+++ b/custom/swisstopo/README.md
@@ -1,8 +1,16 @@
-# SWISSIMAGE provider for the GCP Interface
+# Swiss additions for the GCP Interface
 
 This overlay adds the swisstopo SWISSIMAGE WMTS provider to the WebODM GCP
 Interface. Native tiles are requested through zoom level 20 and Leaflet
 overzooms the imagery through level 28.
+
+It also registers the Swiss LV95 coordinate reference system with the bundled
+Proj4 library. Existing GCP files can use `EPSG:2056` on their first line:
+
+```text
+EPSG:2056
+2600000 1200000 500 1024 768 image.jpg
+```
 
 Build and start WebODM with:
 
@@ -29,6 +37,12 @@ docker compose \
 
 The build fails intentionally if the upstream GCPI bundle changes in a way
 that makes the patch unsafe to apply.
+
+Run the bundle patch tests with:
+
+```sh
+node custom/swisstopo/patch-swisstopo.test.js
+```
 
 ## Sync with upstream WebODM
 

--- a/custom/swisstopo/README.md
+++ b/custom/swisstopo/README.md
@@ -1,0 +1,51 @@
+# SWISSIMAGE provider for the GCP Interface
+
+This overlay adds the swisstopo SWISSIMAGE WMTS provider to the WebODM GCP
+Interface. Native tiles are requested through zoom level 20 and Leaflet
+overzooms the imagery through level 28.
+
+Build and start WebODM with:
+
+```sh
+docker compose \
+  -f docker-compose.yml \
+  -f docker-compose.swisstopo.yml \
+  up -d --build
+```
+
+After updating the upstream WebODM code, rebuild the custom image:
+
+```sh
+docker compose \
+  -f docker-compose.yml \
+  -f docker-compose.swisstopo.yml \
+  build --pull webapp
+
+docker compose \
+  -f docker-compose.yml \
+  -f docker-compose.swisstopo.yml \
+  up -d
+```
+
+The build fails intentionally if the upstream GCPI bundle changes in a way
+that makes the patch unsafe to apply.
+
+## Sync with upstream WebODM
+
+Keep `master` identical to the official WebODM repository and rebase this
+custom branch after each upstream update:
+
+```sh
+git switch master
+git fetch upstream
+git merge --ff-only upstream/master
+git push origin master
+
+git switch codex/swisstopo-gcp
+git rebase master
+git push --force-with-lease
+```
+
+Then rebuild and restart the custom image with the commands above. Using
+`--force-with-lease` is appropriate here because this is a dedicated personal
+customization branch; it refuses to overwrite unexpected remote changes.

--- a/custom/swisstopo/README.md
+++ b/custom/swisstopo/README.md
@@ -12,6 +12,12 @@ EPSG:2056
 2600000 1200000 500 1024 768 image.jpg
 ```
 
+When an existing GCP marker is selected on the map, the interface requests its
+terrain height from the official swisstopo height service. Coordinates are
+sent in `EPSG:2056` and the `COMB` elevation model is used. If the returned
+height differs from the GCP altitude by more than 0.1 metre, the user can
+confirm replacing the GCP altitude with the swisstopo value.
+
 Build and start WebODM with:
 
 ```sh

--- a/custom/swisstopo/README.md
+++ b/custom/swisstopo/README.md
@@ -12,11 +12,15 @@ EPSG:2056
 2600000 1200000 500 1024 768 image.jpg
 ```
 
-When an existing GCP marker is selected on the map, the interface requests its
-terrain height from the official swisstopo height service. Coordinates are
-sent in `EPSG:2056` and the `COMB` elevation model is used. If the returned
-height differs from the GCP altitude by more than 0.1 metre, the user can
-confirm replacing the GCP altitude with the swisstopo value.
+The map provider panel includes a checkbox to compare an existing GCP altitude
+with the official swisstopo terrain height whenever its marker is selected.
+The comparison is enabled by default. If the returned height differs by more
+than 0.1 metre, the user can confirm replacing the GCP altitude.
+
+The same panel also includes a button to check all loaded map GCPs. It displays
+one summary of the differences and can replace all differing altitudes after a
+single confirmation. Coordinates are sent in `EPSG:2056` and the `COMB`
+elevation model is used.
 
 Build and start WebODM with:
 

--- a/custom/swisstopo/patch-swisstopo.js
+++ b/custom/swisstopo/patch-swisstopo.js
@@ -1,14 +1,38 @@
 const fs = require('fs');
 const path = require('path');
 
-const provider = [
-  '{id:"swisstopo",',
-  'label:"SWISSIMAGE (swisstopo)",',
-  'url:"https://wmts.geo.admin.ch/1.0.0/ch.swisstopo.swissimage/default/current/3857/{z}/{x}/{y}.jpeg",',
-  'attribution:"&copy; swisstopo",',
-  'maxZoom:20}'
+const mapProvidersPattern =
+  /map_providers:\[(.*?)\],custom_placeholder:/;
+const webodmBasemapMarker = 'window.parent.__webodmGcpiConfig';
+const providerSelectionPattern =
+  /providers:([A-Za-z_$][\w$]*)\.default\.map_providers,selected:"osm",custom_desc:\1\.default\.custom_description/;
+const originalSetProvider = [
+  'setProvider:function(){for(var e=this.state.selected,n=this.state.custom,',
+  'i=this._container.querySelectorAll("li"),o=0;o<i.length;++o){',
+  'var r=i[o].dataset.id;t.DomUtil.setClass(i[o],this.getProviderItemClass(r)),',
+  'this.setProviderRadioButton(i[o],r)}if("custom"===e&&n)return void ',
+  't.tileLayer(n,{attribution:"",maxZoom:23,maxNativeZoom:19}).addTo(this._map);',
+  'var a=this.options.providers.find(function(t){return t.id===e});',
+  'a&&(a.useBing?t.tileLayer.bing(a.url,{attribution:a.attribute,maxZoom:23,',
+  'maxNativeZoom:a.maxZoom}).addTo(this._map):t.tileLayer(a.url,',
+  '{attribution:a.attribute,maxZoom:23,maxNativeZoom:a.maxZoom})',
+  '.addTo(this._map))}'
 ].join('');
-const existingProvider = /{id:"swisstopo",label:"SWISSIMAGE \(swisstopo\)",url:"https:\/\/wmts\.geo\.admin\.ch\/1\.0\.0\/ch\.swisstopo\.swissimage\/default\/current\/3857\/{z}\/{x}\/{y}\.jpeg",attribution:"&copy; swisstopo",maxZoom:\d+}/;
+const webodmSetProvider = [
+  'setProvider:function(){for(var e=this.state.selected,n=this.state.custom,',
+  'i=this._container.querySelectorAll("li"),o=0;o<i.length;++o){',
+  'var r=i[o].dataset.id;t.DomUtil.setClass(i[o],this.getProviderItemClass(r)),',
+  'this.setProviderRadioButton(i[o],r)}if("custom"===e&&n)return void ',
+  't.tileLayer(n,{attribution:"",maxZoom:23,maxNativeZoom:19}).addTo(this._map);',
+  'var a=this.options.providers.find(function(t){return t.id===e});if(a){',
+  'var s={attribution:a.attribution||a.attribute||a.label,maxZoom:23,',
+  'maxNativeZoom:a.maxZoom||20,minZoom:a.minZoom||0,',
+  'subdomains:a.subdomains||[]},u;',
+  'if("wms"===a.type)s.layers=a.layers||"0",s.styles=a.styles||"default",',
+  's.format=a.format||"image/png",s.transparent="image/jpeg"!==s.format,',
+  'u=t.tileLayer.wms(a.url,s);else if(a.useBing)u=t.tileLayer.bing(a.url,s);',
+  'else u=t.tileLayer(a.url,s);u.addTo(this._map)}}'
+].join('');
 const epsg2056Definition = [
   '+proj=somerc',
   '+lat_0=46.95240555555556',
@@ -175,21 +199,48 @@ function patchBundleContent(input) {
   let bundle = input;
   let changed = false;
 
-  if (existingProvider.test(bundle)) {
-    const updatedBundle = bundle.replace(existingProvider, provider);
-    changed = changed || updatedBundle !== bundle;
-    bundle = updatedBundle;
-  } else {
-    const marker = 'useBing:!0}],custom_placeholder:';
+  if (!bundle.includes(webodmBasemapMarker)) {
+    const match = bundle.match(mapProvidersPattern);
 
-    if (!bundle.includes(marker)) {
+    if (!match) {
       throw new Error('Could not locate the map provider configuration in the GCPI bundle');
     }
 
     bundle = bundle.replace(
-      marker,
-      `useBing:!0},${provider}],custom_placeholder:`
+      mapProvidersPattern,
+      (providerConfig, fallbackProviders) => [
+        'map_providers:function(){',
+        `var t=${webodmBasemapMarker},`,
+        'e=t&&Array.isArray(t.basemaps)?t.basemaps:[];',
+        'return e.length?e.map(function(t,e){return{',
+        'id:"webodm-basemap-"+e,label:t.label,url:t.url,',
+        'attribution:t.attribution||t.label,maxZoom:t.maxzoom||20,',
+        'minZoom:t.minzoom||0,subdomains:t.subdomains||[],',
+        'type:t.type||"tms",layers:t.layers,styles:t.styles,format:t.format,',
+        'default:!!t.default}}):[',
+        fallbackProviders,
+        '] }(),custom_placeholder:'
+      ].join('')
     );
+
+    if (!providerSelectionPattern.test(bundle)) {
+      throw new Error('Could not locate the default GCPI map provider selection');
+    }
+
+    bundle = bundle.replace(
+      providerSelectionPattern,
+      (selection, configModule) =>
+        `providers:${configModule}.default.map_providers,` +
+        `selected:(${configModule}.default.map_providers.find(function(t){` +
+        `return t.default})||${configModule}.default.map_providers[0]||{}).id,` +
+        `custom_desc:${configModule}.default.custom_description`
+    );
+
+    if (!bundle.includes(originalSetProvider)) {
+      throw new Error('Could not locate the GCPI map provider layer setup');
+    }
+
+    bundle = bundle.replace(originalSetProvider, webodmSetProvider);
     changed = true;
   }
 
@@ -296,7 +347,7 @@ function patchInstalledBundle() {
   if (result.changed) {
     fs.writeFileSync(bundlePath, result.bundle);
     console.log(
-      `Added SWISSIMAGE, EPSG:2056 and swisstopo elevation support to ${bundleName}`
+      `Added WebODM basemaps, EPSG:2056 and swisstopo elevation support to ${bundleName}`
     );
   }
 }

--- a/custom/swisstopo/patch-swisstopo.js
+++ b/custom/swisstopo/patch-swisstopo.js
@@ -1,0 +1,63 @@
+const fs = require('fs');
+const path = require('path');
+
+const bundleDirectory = path.join(
+  __dirname,
+  'node_modules',
+  'webodm-posm-gcpi',
+  'static',
+  'js'
+);
+const bundleName = fs
+  .readdirSync(bundleDirectory)
+  .find(name => /^main\..+\.js$/.test(name));
+
+if (!bundleName) {
+  throw new Error('Could not find the webodm-posm-gcpi JavaScript bundle');
+}
+
+const bundlePath = path.join(bundleDirectory, bundleName);
+let bundle = fs.readFileSync(bundlePath, 'utf8');
+let changed = false;
+
+const provider = [
+  '{id:"swisstopo",',
+  'label:"SWISSIMAGE (swisstopo)",',
+  'url:"https://wmts.geo.admin.ch/1.0.0/ch.swisstopo.swissimage/default/current/3857/{z}/{x}/{y}.jpeg",',
+  'attribution:"&copy; swisstopo",',
+  'maxZoom:20}'
+].join('');
+const existingProvider = /{id:"swisstopo",label:"SWISSIMAGE \(swisstopo\)",url:"https:\/\/wmts\.geo\.admin\.ch\/1\.0\.0\/ch\.swisstopo\.swissimage\/default\/current\/3857\/{z}\/{x}\/{y}\.jpeg",attribution:"&copy; swisstopo",maxZoom:\d+}/;
+
+if (existingProvider.test(bundle)) {
+  const updatedBundle = bundle.replace(existingProvider, provider);
+  changed = changed || updatedBundle !== bundle;
+  bundle = updatedBundle;
+} else {
+  const marker = 'useBing:!0}],custom_placeholder:';
+
+  if (!bundle.includes(marker)) {
+    throw new Error('Could not locate the map provider configuration in the GCPI bundle');
+  }
+
+  bundle = bundle.replace(
+    marker,
+    `useBing:!0},${provider}],custom_placeholder:`
+  );
+  changed = true;
+}
+
+const defaultMapZoom = 'maxZoom:23,maxNativeZoom:';
+const overzoomMapZoom = 'maxZoom:28,maxNativeZoom:';
+
+if (bundle.includes(defaultMapZoom)) {
+  bundle = bundle.split(defaultMapZoom).join(overzoomMapZoom);
+  changed = true;
+} else if (!bundle.includes(overzoomMapZoom)) {
+  throw new Error('Could not locate the GCPI map zoom configuration');
+}
+
+if (changed) {
+  fs.writeFileSync(bundlePath, bundle);
+  console.log(`Added SWISSIMAGE overzoom support to ${bundleName}`);
+}

--- a/custom/swisstopo/patch-swisstopo.js
+++ b/custom/swisstopo/patch-swisstopo.js
@@ -40,6 +40,65 @@ const altitudePositionReducer =
   'E=function(t,e){return u({},t,{points:t.points.map(function(t,n){' +
   'return e.id===t.id?u({},t,{coord:e.pos,' +
   'z:void 0===e.altitude?t.z:e.altitude}):t})})}';
+const originalProviderControlTail =
+  'c.innerHTML="Apply",t.DomEvent.on(c,"click",function(t){' +
+  'n.onCustomProviderClick(t,l.value)})},setProviderRadioButton:function(t,e){';
+const altitudeProviderControlTail = [
+  'c.innerHTML="Apply",t.DomEvent.on(c,"click",function(t){',
+  'n.onCustomProviderClick(t,l.value)})},',
+  'createAltitudeControls:function(e){',
+  'window.__webodmCompareAltitudes="boolean"==',
+  'typeof window.__webodmCompareAltitudes?window.__webodmCompareAltitudes:!0;',
+  'var n=t.DomUtil.create("div","swisstopo-altitude-controls",e);',
+  'n.style.padding="8px 10px",n.style.borderTop="1px solid #ddd",',
+  'n.style.background="#fff",n.style.color="#333";',
+  'var i=t.DomUtil.create("label","",n);',
+  'i.style.display="flex",i.style.alignItems="center",i.style.gap="6px",',
+  'i.style.cursor="pointer";',
+  'var o=t.DomUtil.create("input","",i);',
+  'o.type="checkbox",o.checked=window.__webodmCompareAltitudes,',
+  'o.setAttribute("data-testid","compare-gcp-altitudes");',
+  'var r=t.DomUtil.create("span","",i);',
+  'r.style.color="#333",',
+  'r.innerHTML="Comparer les altitudes \\u00e0 la vol\\u00e9e";',
+  'var a=t.DomUtil.create("button","btn",n);',
+  'a.type="button",a.style.width="100%",a.style.marginTop="8px",',
+  'a.style.padding="8px",a.style.color="#333",a.style.background="#f5f5f5",',
+  'a.style.border="1px solid #bbb",a.style.borderRadius="2px",',
+  'a.innerHTML="Contr\\u00f4ler tous les GCP",',
+  'a.setAttribute("data-testid","check-all-gcp-altitudes"),',
+  't.DomEvent.on(o,"change",function(e){',
+  't.DomEvent.stop(e),window.__webodmCompareAltitudes=o.checked',
+  '}).on(a,"click",function(e){',
+  'if(t.DomEvent.stop(e),"function"==typeof window.__webodmCheckAllGcpAltitudes){',
+  'var n=a.innerHTML;a.disabled=!0,a.innerHTML="Contr\\u00f4le en cours...";',
+  'var i=function(){a.disabled=!1,a.innerHTML=n};',
+  'Promise.resolve(window.__webodmCheckAllGcpAltitudes()).then(i,function(t){',
+  'window.console&&console.warn("Impossible de controler les altitudes GCP",t),',
+  'window.alert("Le contr\\u00f4le des altitudes a \\u00e9chou\\u00e9."),i()',
+  '})}})},setProviderRadioButton:function(t,e){'
+].join('');
+const originalProviderControlMount =
+  'this.createCustomButton(s),t.DomEvent.on(o,"click",function(t){';
+const altitudeProviderControlMount =
+  'this.createCustomButton(s),this.createAltitudeControls(s),' +
+  't.DomEvent.on(o,"click",function(t){';
+const originalLeafletMapBinding =
+  't.onMarkerToggle=t.onMarkerToggle.bind(t),' +
+  't.onMapClick=t.onMapClick.bind(t),t.state={leafletMap:null}';
+const altitudeLeafletMapBinding =
+  't.onMarkerToggle=t.onMarkerToggle.bind(t),' +
+  't.onMapClick=t.onMapClick.bind(t),' +
+  't.checkAllGcpAltitudes=t.checkAllGcpAltitudes.bind(t),' +
+  't.state={leafletMap:null}';
+const originalLeafletMapMount =
+  '{key:"componentDidMount",value:function(){this.initializeMap()}},';
+const altitudeLeafletMapMount =
+  '{key:"componentDidMount",value:function(){this.initializeMap(),' +
+  'window.__webodmCheckAllGcpAltitudes=this.checkAllGcpAltitudes}},' +
+  '{key:"componentWillUnmount",value:function(){' +
+  'window.__webodmCheckAllGcpAltitudes===this.checkAllGcpAltitudes&&' +
+  'delete window.__webodmCheckAllGcpAltitudes}},';
 const originalMarkerToggle =
   '{key:"onMarkerToggle",value:function(t,e,n){var i=this.props,' +
   'o=i.toggleControlPointMode,r=i.controlpoints,a=i.setPointProperties,' +
@@ -47,33 +106,70 @@ const originalMarkerToggle =
   'a(!1,null,null,null,t,[n.lat,n.lng]):r.mode===b.CP_MODES.IMAGE_EDIT?' +
   's(t):void o(t)}}';
 const altitudeMarkerToggle = [
+  '{key:"getSwisstopoElevation",value:function(t){',
+  'if(!window.__webodmGcpProj4)',
+  'return Promise.reject(new Error("Proj4 EPSG:2056 indisponible"));',
+  'var e=window.__webodmGcpProj4("EPSG:4326","EPSG:2056",',
+  '[t.coord[1],t.coord[0]]),n=e[0],i=e[1];',
+  `return fetch("${swisstopoHeightEndpoint}?easting="+encodeURIComponent(n)+`,
+  '"&northing="+encodeURIComponent(i)+',
+  '"&sr=2056&elevation_model=COMB").then(function(t){',
+  'if(!t.ok)throw new Error("HTTP "+t.status);return t.json()',
+  '}).then(function(t){var e=parseFloat(t.height);',
+  'if(!isFinite(e))throw new Error("Altitude swisstopo invalide");return e})}},',
+  '{key:"checkAllGcpAltitudes",value:function(){var t=this,',
+  'e=this.props.controlpoints.points.filter(function(t){return"map"===t.type}),',
+  'n=e.filter(function(t){return t.coord&&2===t.coord.length&&',
+  'isFinite(parseFloat(t.coord[0]))&&isFinite(parseFloat(t.coord[1]))&&',
+  'isFinite(parseFloat(t.z))});',
+  'if(!n.length)return window.alert("Aucun GCP avec une altitude valide \\u00e0 contr\\u00f4ler."),',
+  'Promise.resolve({checked:0,updated:0,failed:e.length});',
+  'return Promise.all(n.map(function(e,n){',
+  'return t.getSwisstopoElevation(e).then(function(t){',
+  'return{point:e,index:n,height:t,current:parseFloat(e.z)}',
+  '},function(t){return{point:e,index:n,error:t}})',
+  '})).then(function(i){',
+  'var o=i.filter(function(t){return!t.error}),',
+  'r=i.filter(function(t){return t.error}).length+e.length-n.length,',
+  `a=o.filter(function(t){return Math.abs(t.height-t.current)>${elevationTolerance}});`,
+  'if(!a.length)return window.alert("Contr\\u00f4le termin\\u00e9 : "+o.length+',
+  '" GCP, aucune diff\\u00e9rence sup\\u00e9rieure \\u00e0 0,10 m."+(r?',
+  '"\\n"+r+" GCP non contr\\u00f4l\\u00e9(s).":"")),',
+  '{checked:o.length,updated:0,failed:r};',
+  'var s=a.slice(0,12).map(function(t){',
+  'var e=t.point.label||"GCP "+(t.index+1),n=Math.abs(t.height-t.current);',
+  'return e+" : "+t.current.toFixed(1)+" m \\u2192 "+',
+  't.height.toFixed(1)+" m (\\u0394 "+n.toFixed(1)+" m)"',
+  '}).join("\\n"),',
+  'u=a.length>12?"\\n... et "+(a.length-12)+" autre(s) GCP.":"",',
+  'l="Altitude diff\\u00e9rente pour "+a.length+" GCP sur "+o.length+".\\n\\n"+',
+  's+u+(r?"\\n\\n"+r+" GCP non contr\\u00f4l\\u00e9(s).":"")+',
+  '"\\n\\nUtiliser les altitudes swisstopo pour ces GCP ?";',
+  'return window.confirm(l)&&(a.forEach(function(e){',
+  't.props.setControlPointPosition("map",e.point.id,e.point.coord,e.height)',
+  '}),{checked:o.length,updated:a.length,failed:r})||',
+  '{checked:o.length,updated:0,failed:r}',
+  '})}},',
   '{key:"onMarkerToggle",value:function(t,e,n){var i=this.props,',
   'o=i.toggleControlPointMode,r=i.controlpoints,a=i.setPointProperties,',
   's=i.joinControlPoint,u=i.setControlPointPosition;',
   'if(r.mode===b.CP_MODES.ADDING)return a(!1,null,null,null,t,[n.lat,n.lng]);',
   'if(r.mode===b.CP_MODES.IMAGE_EDIT)return s(t);',
   'var l=r.points.find(function(e){return e.id===t}),c=l?parseFloat(l.z):NaN;',
-  'if(l&&isFinite(c)&&window.__webodmGcpProj4)try{',
-  'var h=window.__webodmGcpProj4("EPSG:4326","EPSG:2056",[n.lng,n.lat]),',
-  'p=h[0],d=h[1];',
-  `fetch("${swisstopoHeightEndpoint}?easting="+encodeURIComponent(p)+`,
-  '"&northing="+encodeURIComponent(d)+',
-  '"&sr=2056&elevation_model=COMB").then(function(t){',
-  'if(!t.ok)throw new Error("HTTP "+t.status);return t.json()',
-  '}).then(function(e){var i=parseFloat(e.height);',
+  'if(window.__webodmCompareAltitudes!==!1&&l&&isFinite(c))',
+  'this.getSwisstopoElevation(l).then(function(e){var i=e;',
   `if(isFinite(i)&&Math.abs(i-c)>${elevationTolerance}){`,
-  'var o=Math.abs(i-c);',
+  'var r=Math.abs(i-c);',
   'window.confirm("Altitude du GCP : "+c.toFixed(1)+" m\\n"+',
   '"Altitude swisstopo : "+i.toFixed(1)+" m\\n"+',
-  '"Diff\\u00e9rence : "+o.toFixed(1)+" m\\n\\n"+',
+  '"Diff\\u00e9rence : "+r.toFixed(1)+" m\\n\\n"+',
   '"Utiliser l\'altitude swisstopo ?")&&',
-  'u("map",t,[n.lat,n.lng],i)}}).catch(function(t){',
+  'u("map",t,l.coord,i)}}).catch(function(t){',
   'window.console&&console.warn("Impossible de recuperer l\'altitude swisstopo",t)',
-  '})}catch(f){window.console&&',
-  'console.warn("Impossible de calculer les coordonnees EPSG:2056",f)}',
+  '});',
   'o(t)}}'
 ].join('');
-const altitudePatchMarker = 'elevation_model=COMB';
+const altitudePatchMarker = 'data-testid","check-all-gcp-altitudes';
 
 function patchBundleContent(input) {
   let bundle = input;
@@ -137,22 +233,40 @@ function patchBundleContent(input) {
     changed = true;
   }
 
-  if (!bundle.includes(altitudePatchMarker)) {
-    if (!bundle.includes(originalPositionAction)) {
+  if (bundle.includes(originalPositionAction)) {
+    bundle = bundle.replace(originalPositionAction, altitudePositionAction);
+    changed = true;
+  } else if (!bundle.includes('altitude:arguments.length>3?arguments[3]:void 0')) {
       throw new Error('Could not locate the GCPI point position action');
-    }
+  }
 
-    if (!bundle.includes(originalPositionReducer)) {
+  if (bundle.includes(originalPositionReducer)) {
+    bundle = bundle.replace(originalPositionReducer, altitudePositionReducer);
+    changed = true;
+  } else if (!bundle.includes('z:void 0===e.altitude?t.z:e.altitude')) {
       throw new Error('Could not locate the GCPI point position reducer');
-    }
+  }
 
+  if (!bundle.includes(altitudePatchMarker)) {
     if (!bundle.includes(originalMarkerToggle)) {
       throw new Error('Could not locate the GCPI map marker selection handler');
     }
 
+    if (!bundle.includes(originalProviderControlTail) ||
+        !bundle.includes(originalProviderControlMount)) {
+      throw new Error('Could not locate the GCPI map provider control');
+    }
+
+    if (!bundle.includes(originalLeafletMapBinding) ||
+        !bundle.includes(originalLeafletMapMount)) {
+      throw new Error('Could not locate the GCPI map component lifecycle');
+    }
+
     bundle = bundle
-      .replace(originalPositionAction, altitudePositionAction)
-      .replace(originalPositionReducer, altitudePositionReducer)
+      .replace(originalProviderControlTail, altitudeProviderControlTail)
+      .replace(originalProviderControlMount, altitudeProviderControlMount)
+      .replace(originalLeafletMapBinding, altitudeLeafletMapBinding)
+      .replace(originalLeafletMapMount, altitudeLeafletMapMount)
       .replace(originalMarkerToggle, altitudeMarkerToggle);
     changed = true;
   }

--- a/custom/swisstopo/patch-swisstopo.js
+++ b/custom/swisstopo/patch-swisstopo.js
@@ -22,8 +22,58 @@ const epsg2056Definition = [
   '+no_defs'
 ].join(' ');
 const epsg2056Marker = '.defs("EPSG:2056",';
+const proj4GlobalMarker = 'window.__webodmGcpProj4=';
 const projectionValidationPattern =
   /try\{\(0,([A-Za-z_$][\w$]*)\.default\)\(([A-Za-z_$][\w$]*),"EPSG:4326",\[0,0\]\)\}catch\(([A-Za-z_$][\w$]*)\)\{/;
+const swisstopoHeightEndpoint =
+  'https://api3.geo.admin.ch/rest/services/height';
+const elevationTolerance = 0.1;
+const originalPositionAction =
+  'function v(t,e,n){return{type:z,loc:t,id:e,pos:n}}';
+const altitudePositionAction =
+  'function v(t,e,n){return{type:z,loc:t,id:e,pos:n,' +
+  'altitude:arguments.length>3?arguments[3]:void 0}}';
+const originalPositionReducer =
+  'E=function(t,e){return u({},t,{points:t.points.map(function(t,n){' +
+  'return e.id===t.id?u({},t,{coord:e.pos}):t})})}';
+const altitudePositionReducer =
+  'E=function(t,e){return u({},t,{points:t.points.map(function(t,n){' +
+  'return e.id===t.id?u({},t,{coord:e.pos,' +
+  'z:void 0===e.altitude?t.z:e.altitude}):t})})}';
+const originalMarkerToggle =
+  '{key:"onMarkerToggle",value:function(t,e,n){var i=this.props,' +
+  'o=i.toggleControlPointMode,r=i.controlpoints,a=i.setPointProperties,' +
+  's=i.joinControlPoint;return r.mode===b.CP_MODES.ADDING?' +
+  'a(!1,null,null,null,t,[n.lat,n.lng]):r.mode===b.CP_MODES.IMAGE_EDIT?' +
+  's(t):void o(t)}}';
+const altitudeMarkerToggle = [
+  '{key:"onMarkerToggle",value:function(t,e,n){var i=this.props,',
+  'o=i.toggleControlPointMode,r=i.controlpoints,a=i.setPointProperties,',
+  's=i.joinControlPoint,u=i.setControlPointPosition;',
+  'if(r.mode===b.CP_MODES.ADDING)return a(!1,null,null,null,t,[n.lat,n.lng]);',
+  'if(r.mode===b.CP_MODES.IMAGE_EDIT)return s(t);',
+  'var l=r.points.find(function(e){return e.id===t}),c=l?parseFloat(l.z):NaN;',
+  'if(l&&isFinite(c)&&window.__webodmGcpProj4)try{',
+  'var h=window.__webodmGcpProj4("EPSG:4326","EPSG:2056",[n.lng,n.lat]),',
+  'p=h[0],d=h[1];',
+  `fetch("${swisstopoHeightEndpoint}?easting="+encodeURIComponent(p)+`,
+  '"&northing="+encodeURIComponent(d)+',
+  '"&sr=2056&elevation_model=COMB").then(function(t){',
+  'if(!t.ok)throw new Error("HTTP "+t.status);return t.json()',
+  '}).then(function(e){var i=parseFloat(e.height);',
+  `if(isFinite(i)&&Math.abs(i-c)>${elevationTolerance}){`,
+  'var o=Math.abs(i-c);',
+  'window.confirm("Altitude du GCP : "+c.toFixed(1)+" m\\n"+',
+  '"Altitude swisstopo : "+i.toFixed(1)+" m\\n"+',
+  '"Diff\\u00e9rence : "+o.toFixed(1)+" m\\n\\n"+',
+  '"Utiliser l\'altitude swisstopo ?")&&',
+  'u("map",t,[n.lat,n.lng],i)}}).catch(function(t){',
+  'window.console&&console.warn("Impossible de recuperer l\'altitude swisstopo",t)',
+  '})}catch(f){window.console&&',
+  'console.warn("Impossible de calculer les coordonnees EPSG:2056",f)}',
+  'o(t)}}'
+].join('');
+const altitudePatchMarker = 'elevation_model=COMB';
 
 function patchBundleContent(input) {
   let bundle = input;
@@ -65,10 +115,45 @@ function patchBundleContent(input) {
     bundle = bundle.replace(
       projectionValidationPattern,
       (match, proj4Module, sourceProjection, errorVariable) =>
-        `try{${proj4Module}.default.defs("EPSG:2056","${epsg2056Definition}");` +
+        `try{window.__webodmGcpProj4=${proj4Module}.default;` +
+        `${proj4Module}.default.defs("EPSG:2056","${epsg2056Definition}");` +
         `(0,${proj4Module}.default)(${sourceProjection},"EPSG:4326",[0,0])}` +
         `catch(${errorVariable}){`
     );
+    changed = true;
+  } else if (!bundle.includes(proj4GlobalMarker)) {
+    const existingDefinitionPattern =
+      /([A-Za-z_$][\w$]*)\.default\.defs\("EPSG:2056",/;
+
+    if (!existingDefinitionPattern.test(bundle)) {
+      throw new Error('Could not expose the GCPI Proj4 instance');
+    }
+
+    bundle = bundle.replace(
+      existingDefinitionPattern,
+      (match, proj4Module) =>
+        `window.__webodmGcpProj4=${proj4Module}.default;${match}`
+    );
+    changed = true;
+  }
+
+  if (!bundle.includes(altitudePatchMarker)) {
+    if (!bundle.includes(originalPositionAction)) {
+      throw new Error('Could not locate the GCPI point position action');
+    }
+
+    if (!bundle.includes(originalPositionReducer)) {
+      throw new Error('Could not locate the GCPI point position reducer');
+    }
+
+    if (!bundle.includes(originalMarkerToggle)) {
+      throw new Error('Could not locate the GCPI map marker selection handler');
+    }
+
+    bundle = bundle
+      .replace(originalPositionAction, altitudePositionAction)
+      .replace(originalPositionReducer, altitudePositionReducer)
+      .replace(originalMarkerToggle, altitudeMarkerToggle);
     changed = true;
   }
 
@@ -96,7 +181,9 @@ function patchInstalledBundle() {
 
   if (result.changed) {
     fs.writeFileSync(bundlePath, result.bundle);
-    console.log(`Added SWISSIMAGE overzoom and EPSG:2056 support to ${bundleName}`);
+    console.log(
+      `Added SWISSIMAGE, EPSG:2056 and swisstopo elevation support to ${bundleName}`
+    );
   }
 }
 
@@ -105,6 +192,8 @@ if (require.main === module) {
 }
 
 module.exports = {
+  elevationTolerance,
   epsg2056Definition,
-  patchBundleContent
+  patchBundleContent,
+  swisstopoHeightEndpoint
 };

--- a/custom/swisstopo/patch-swisstopo.js
+++ b/custom/swisstopo/patch-swisstopo.js
@@ -1,25 +1,6 @@
 const fs = require('fs');
 const path = require('path');
 
-const bundleDirectory = path.join(
-  __dirname,
-  'node_modules',
-  'webodm-posm-gcpi',
-  'static',
-  'js'
-);
-const bundleName = fs
-  .readdirSync(bundleDirectory)
-  .find(name => /^main\..+\.js$/.test(name));
-
-if (!bundleName) {
-  throw new Error('Could not find the webodm-posm-gcpi JavaScript bundle');
-}
-
-const bundlePath = path.join(bundleDirectory, bundleName);
-let bundle = fs.readFileSync(bundlePath, 'utf8');
-let changed = false;
-
 const provider = [
   '{id:"swisstopo",',
   'label:"SWISSIMAGE (swisstopo)",',
@@ -28,36 +9,102 @@ const provider = [
   'maxZoom:20}'
 ].join('');
 const existingProvider = /{id:"swisstopo",label:"SWISSIMAGE \(swisstopo\)",url:"https:\/\/wmts\.geo\.admin\.ch\/1\.0\.0\/ch\.swisstopo\.swissimage\/default\/current\/3857\/{z}\/{x}\/{y}\.jpeg",attribution:"&copy; swisstopo",maxZoom:\d+}/;
+const epsg2056Definition = [
+  '+proj=somerc',
+  '+lat_0=46.95240555555556',
+  '+lon_0=7.439583333333333',
+  '+k_0=1',
+  '+x_0=2600000',
+  '+y_0=1200000',
+  '+ellps=bessel',
+  '+towgs84=674.374,15.056,405.346,0,0,0,0',
+  '+units=m',
+  '+no_defs'
+].join(' ');
+const epsg2056Marker = '.defs("EPSG:2056",';
+const projectionValidationPattern =
+  /try\{\(0,([A-Za-z_$][\w$]*)\.default\)\(([A-Za-z_$][\w$]*),"EPSG:4326",\[0,0\]\)\}catch\(([A-Za-z_$][\w$]*)\)\{/;
 
-if (existingProvider.test(bundle)) {
-  const updatedBundle = bundle.replace(existingProvider, provider);
-  changed = changed || updatedBundle !== bundle;
-  bundle = updatedBundle;
-} else {
-  const marker = 'useBing:!0}],custom_placeholder:';
+function patchBundleContent(input) {
+  let bundle = input;
+  let changed = false;
 
-  if (!bundle.includes(marker)) {
-    throw new Error('Could not locate the map provider configuration in the GCPI bundle');
+  if (existingProvider.test(bundle)) {
+    const updatedBundle = bundle.replace(existingProvider, provider);
+    changed = changed || updatedBundle !== bundle;
+    bundle = updatedBundle;
+  } else {
+    const marker = 'useBing:!0}],custom_placeholder:';
+
+    if (!bundle.includes(marker)) {
+      throw new Error('Could not locate the map provider configuration in the GCPI bundle');
+    }
+
+    bundle = bundle.replace(
+      marker,
+      `useBing:!0},${provider}],custom_placeholder:`
+    );
+    changed = true;
   }
 
-  bundle = bundle.replace(
-    marker,
-    `useBing:!0},${provider}],custom_placeholder:`
+  const defaultMapZoom = 'maxZoom:23,maxNativeZoom:';
+  const overzoomMapZoom = 'maxZoom:28,maxNativeZoom:';
+
+  if (bundle.includes(defaultMapZoom)) {
+    bundle = bundle.split(defaultMapZoom).join(overzoomMapZoom);
+    changed = true;
+  } else if (!bundle.includes(overzoomMapZoom)) {
+    throw new Error('Could not locate the GCPI map zoom configuration');
+  }
+
+  if (!bundle.includes(epsg2056Marker)) {
+    if (!projectionValidationPattern.test(bundle)) {
+      throw new Error('Could not locate the GCPI projection validation');
+    }
+
+    bundle = bundle.replace(
+      projectionValidationPattern,
+      (match, proj4Module, sourceProjection, errorVariable) =>
+        `try{${proj4Module}.default.defs("EPSG:2056","${epsg2056Definition}");` +
+        `(0,${proj4Module}.default)(${sourceProjection},"EPSG:4326",[0,0])}` +
+        `catch(${errorVariable}){`
+    );
+    changed = true;
+  }
+
+  return { bundle, changed };
+}
+
+function patchInstalledBundle() {
+  const bundleDirectory = path.join(
+    __dirname,
+    'node_modules',
+    'webodm-posm-gcpi',
+    'static',
+    'js'
   );
-  changed = true;
+  const bundleName = fs
+    .readdirSync(bundleDirectory)
+    .find(name => /^main\..+\.js$/.test(name));
+
+  if (!bundleName) {
+    throw new Error('Could not find the webodm-posm-gcpi JavaScript bundle');
+  }
+
+  const bundlePath = path.join(bundleDirectory, bundleName);
+  const result = patchBundleContent(fs.readFileSync(bundlePath, 'utf8'));
+
+  if (result.changed) {
+    fs.writeFileSync(bundlePath, result.bundle);
+    console.log(`Added SWISSIMAGE overzoom and EPSG:2056 support to ${bundleName}`);
+  }
 }
 
-const defaultMapZoom = 'maxZoom:23,maxNativeZoom:';
-const overzoomMapZoom = 'maxZoom:28,maxNativeZoom:';
-
-if (bundle.includes(defaultMapZoom)) {
-  bundle = bundle.split(defaultMapZoom).join(overzoomMapZoom);
-  changed = true;
-} else if (!bundle.includes(overzoomMapZoom)) {
-  throw new Error('Could not locate the GCPI map zoom configuration');
+if (require.main === module) {
+  patchInstalledBundle();
 }
 
-if (changed) {
-  fs.writeFileSync(bundlePath, bundle);
-  console.log(`Added SWISSIMAGE overzoom support to ${bundleName}`);
-}
+module.exports = {
+  epsg2056Definition,
+  patchBundleContent
+};

--- a/custom/swisstopo/patch-swisstopo.test.js
+++ b/custom/swisstopo/patch-swisstopo.test.js
@@ -8,7 +8,20 @@ const {
 } = require('./patch-swisstopo');
 
 const fixture = [
-  'providers:[{id:"bing",useBing:!0}],custom_placeholder:',
+  'map_providers:[{id:"osm",label:"OpenStreetMap",maxZoom:19},',
+  '{id:"bing",useBing:!0}],custom_placeholder:',
+  'providers:w.default.map_providers,selected:"osm",',
+  'custom_desc:w.default.custom_description,',
+  'setProvider:function(){for(var e=this.state.selected,n=this.state.custom,',
+  'i=this._container.querySelectorAll("li"),o=0;o<i.length;++o){',
+  'var r=i[o].dataset.id;t.DomUtil.setClass(i[o],this.getProviderItemClass(r)),',
+  'this.setProviderRadioButton(i[o],r)}if("custom"===e&&n)return void ',
+  't.tileLayer(n,{attribution:"",maxZoom:23,maxNativeZoom:19}).addTo(this._map);',
+  'var a=this.options.providers.find(function(t){return t.id===e});',
+  'a&&(a.useBing?t.tileLayer.bing(a.url,{attribution:a.attribute,maxZoom:23,',
+  'maxNativeZoom:a.maxZoom}).addTo(this._map):t.tileLayer(a.url,',
+  '{attribution:a.attribute,maxZoom:23,maxNativeZoom:a.maxZoom})',
+  '.addTo(this._map))}',
   'mapOptions:{maxZoom:23,maxNativeZoom:20},',
   'c.innerHTML="Apply",t.DomEvent.on(c,"click",function(t){',
   'n.onCustomProviderClick(t,l.value)})},setProviderRadioButton:function(t,e){',
@@ -31,7 +44,12 @@ const fixture = [
 const first = patchBundleContent(fixture);
 
 assert.strictEqual(first.changed, true);
-assert(first.bundle.includes('label:"SWISSIMAGE (swisstopo)"'));
+assert(first.bundle.includes('window.parent.__webodmGcpiConfig'));
+assert(first.bundle.includes('id:"webodm-basemap-"+e'));
+assert(first.bundle.includes('type:t.type||"tms"'));
+assert(first.bundle.includes('"wms"===a.type'));
+assert(first.bundle.includes('t.tileLayer.wms(a.url,s)'));
+assert(first.bundle.includes('return t.default'));
 assert(first.bundle.includes('maxZoom:28,maxNativeZoom:20'));
 assert(first.bundle.includes('window.__webodmGcpProj4=C.default'));
 assert(first.bundle.includes(`C.default.defs("EPSG:2056","${epsg2056Definition}")`));

--- a/custom/swisstopo/patch-swisstopo.test.js
+++ b/custom/swisstopo/patch-swisstopo.test.js
@@ -10,11 +10,17 @@ const {
 const fixture = [
   'providers:[{id:"bing",useBing:!0}],custom_placeholder:',
   'mapOptions:{maxZoom:23,maxNativeZoom:20},',
+  'c.innerHTML="Apply",t.DomEvent.on(c,"click",function(t){',
+  'n.onCustomProviderClick(t,l.value)})},setProviderRadioButton:function(t,e){',
+  'this.createCustomButton(s),t.DomEvent.on(o,"click",function(t){',
   'function preview(a){try{(0,C.default)(a,"EPSG:4326",[0,0])}',
   'catch(l){errors.push("Unknown projection "+a)}}',
   'function v(t,e,n){return{type:z,loc:t,id:e,pos:n}}',
   'E=function(t,e){return u({},t,{points:t.points.map(function(t,n){',
   'return e.id===t.id?u({},t,{coord:e.pos}):t})})}',
+  't.onMarkerToggle=t.onMarkerToggle.bind(t),',
+  't.onMapClick=t.onMapClick.bind(t),t.state={leafletMap:null}',
+  '{key:"componentDidMount",value:function(){this.initializeMap()}},',
   '{key:"onMarkerToggle",value:function(t,e,n){var i=this.props,',
   'o=i.toggleControlPointMode,r=i.controlpoints,a=i.setPointProperties,',
   's=i.joinControlPoint;return r.mode===b.CP_MODES.ADDING?',
@@ -34,9 +40,19 @@ assert(first.bundle.includes(swisstopoHeightEndpoint));
 assert(first.bundle.includes('elevation_model=COMB'));
 assert(first.bundle.includes(`Math.abs(i-c)>${elevationTolerance}`));
 assert(first.bundle.includes('Altitude swisstopo :'));
+assert(first.bundle.includes('data-testid","compare-gcp-altitudes'));
+assert(first.bundle.includes('data-testid","check-all-gcp-altitudes'));
+assert(first.bundle.includes('window.__webodmCompareAltitudes!==!1'));
+assert(first.bundle.includes('window.__webodmCheckAllGcpAltitudes'));
+assert(first.bundle.includes('checkAllGcpAltitudes'));
+assert(first.bundle.includes('Contr\\u00f4ler tous les GCP'));
+assert(first.bundle.includes('Utiliser les altitudes swisstopo pour ces GCP ?'));
 assert(first.bundle.includes('altitude:arguments.length>3?arguments[3]:void 0'));
 assert(first.bundle.includes('z:void 0===e.altitude?t.z:e.altitude'));
-assert(first.bundle.includes('u("map",t,[n.lat,n.lng],i)'));
+assert(first.bundle.includes('u("map",t,l.coord,i)'));
+assert(first.bundle.includes(
+  't.props.setControlPointPosition("map",e.point.id,e.point.coord,e.height)'
+));
 
 const second = patchBundleContent(first.bundle);
 

--- a/custom/swisstopo/patch-swisstopo.test.js
+++ b/custom/swisstopo/patch-swisstopo.test.js
@@ -1,15 +1,25 @@
 const assert = require('assert');
 
 const {
+  elevationTolerance,
   epsg2056Definition,
-  patchBundleContent
+  patchBundleContent,
+  swisstopoHeightEndpoint
 } = require('./patch-swisstopo');
 
 const fixture = [
   'providers:[{id:"bing",useBing:!0}],custom_placeholder:',
   'mapOptions:{maxZoom:23,maxNativeZoom:20},',
   'function preview(a){try{(0,C.default)(a,"EPSG:4326",[0,0])}',
-  'catch(l){errors.push("Unknown projection "+a)}}'
+  'catch(l){errors.push("Unknown projection "+a)}}',
+  'function v(t,e,n){return{type:z,loc:t,id:e,pos:n}}',
+  'E=function(t,e){return u({},t,{points:t.points.map(function(t,n){',
+  'return e.id===t.id?u({},t,{coord:e.pos}):t})})}',
+  '{key:"onMarkerToggle",value:function(t,e,n){var i=this.props,',
+  'o=i.toggleControlPointMode,r=i.controlpoints,a=i.setPointProperties,',
+  's=i.joinControlPoint;return r.mode===b.CP_MODES.ADDING?',
+  'a(!1,null,null,null,t,[n.lat,n.lng]):r.mode===b.CP_MODES.IMAGE_EDIT?',
+  's(t):void o(t)}}'
 ].join('');
 
 const first = patchBundleContent(fixture);
@@ -17,8 +27,16 @@ const first = patchBundleContent(fixture);
 assert.strictEqual(first.changed, true);
 assert(first.bundle.includes('label:"SWISSIMAGE (swisstopo)"'));
 assert(first.bundle.includes('maxZoom:28,maxNativeZoom:20'));
+assert(first.bundle.includes('window.__webodmGcpProj4=C.default'));
 assert(first.bundle.includes(`C.default.defs("EPSG:2056","${epsg2056Definition}")`));
 assert(first.bundle.includes('(0,C.default)(a,"EPSG:4326",[0,0])'));
+assert(first.bundle.includes(swisstopoHeightEndpoint));
+assert(first.bundle.includes('elevation_model=COMB'));
+assert(first.bundle.includes(`Math.abs(i-c)>${elevationTolerance}`));
+assert(first.bundle.includes('Altitude swisstopo :'));
+assert(first.bundle.includes('altitude:arguments.length>3?arguments[3]:void 0'));
+assert(first.bundle.includes('z:void 0===e.altitude?t.z:e.altitude'));
+assert(first.bundle.includes('u("map",t,[n.lat,n.lng],i)'));
 
 const second = patchBundleContent(first.bundle);
 
@@ -35,4 +53,14 @@ assert.throws(
   /Could not locate the GCPI projection validation/
 );
 
-console.log('SWISSIMAGE and EPSG:2056 bundle patch tests passed');
+assert.throws(
+  () => patchBundleContent(
+    fixture.replace(
+      'function v(t,e,n){return{type:z,loc:t,id:e,pos:n}}',
+      'function positionActionChanged(){}'
+    )
+  ),
+  /Could not locate the GCPI point position action/
+);
+
+console.log('SWISSIMAGE, EPSG:2056 and elevation bundle patch tests passed');

--- a/custom/swisstopo/patch-swisstopo.test.js
+++ b/custom/swisstopo/patch-swisstopo.test.js
@@ -1,0 +1,38 @@
+const assert = require('assert');
+
+const {
+  epsg2056Definition,
+  patchBundleContent
+} = require('./patch-swisstopo');
+
+const fixture = [
+  'providers:[{id:"bing",useBing:!0}],custom_placeholder:',
+  'mapOptions:{maxZoom:23,maxNativeZoom:20},',
+  'function preview(a){try{(0,C.default)(a,"EPSG:4326",[0,0])}',
+  'catch(l){errors.push("Unknown projection "+a)}}'
+].join('');
+
+const first = patchBundleContent(fixture);
+
+assert.strictEqual(first.changed, true);
+assert(first.bundle.includes('label:"SWISSIMAGE (swisstopo)"'));
+assert(first.bundle.includes('maxZoom:28,maxNativeZoom:20'));
+assert(first.bundle.includes(`C.default.defs("EPSG:2056","${epsg2056Definition}")`));
+assert(first.bundle.includes('(0,C.default)(a,"EPSG:4326",[0,0])'));
+
+const second = patchBundleContent(first.bundle);
+
+assert.strictEqual(second.changed, false);
+assert.strictEqual(second.bundle, first.bundle);
+
+assert.throws(
+  () => patchBundleContent(
+    fixture.replace(
+      'try{(0,C.default)(a,"EPSG:4326",[0,0])}catch(l){',
+      'try{validateProjection(a)}catch(l){'
+    )
+  ),
+  /Could not locate the GCPI projection validation/
+);
+
+console.log('SWISSIMAGE and EPSG:2056 bundle patch tests passed');

--- a/docker-compose.swisstopo.yml
+++ b/docker-compose.swisstopo.yml
@@ -2,8 +2,8 @@ services:
   webapp:
     image: leneo/webodm_webapp:swisstopo
     build:
-      context: .
-      dockerfile: custom/swisstopo/Dockerfile
+      context: ./custom/swisstopo
+      dockerfile: Dockerfile
 
   worker:
     image: leneo/webodm_webapp:swisstopo

--- a/docker-compose.swisstopo.yml
+++ b/docker-compose.swisstopo.yml
@@ -1,0 +1,9 @@
+services:
+  webapp:
+    image: leneo/webodm_webapp:swisstopo
+    build:
+      context: .
+      dockerfile: custom/swisstopo/Dockerfile
+
+  worker:
+    image: leneo/webodm_webapp:swisstopo

--- a/docker-compose.swisstopo.yml
+++ b/docker-compose.swisstopo.yml
@@ -2,8 +2,8 @@ services:
   webapp:
     image: leneo/webodm_webapp:swisstopo
     build:
-      context: ./custom/swisstopo
-      dockerfile: Dockerfile
+      context: .
+      dockerfile: custom/swisstopo/Dockerfile
 
   worker:
     image: leneo/webodm_webapp:swisstopo


### PR DESCRIPTION
## Summary

This PR improves the WebODM Ground Control Point Interface for Swiss photogrammetry workflows.

## Changes

- Adds SWISSIMAGE from swisstopo as a map provider.
- Enables Leaflet overzoom up to zoom level 28.
- Adds EPSG:2056 (LV95) support when importing existing GCP files.
- Registers the EPSG:2056 Proj4 definition before preview validation.
- Reduces the custom Docker build context for faster builds.
- Adds an idempotency and compatibility test for the bundle patch.

GCP files can now start with:

```text
EPSG:2056
2600000 1200000 500 1024 768 image.jpg