### PR TITLE
Check that a task's owner can use a processing node

### DIFF
--- a/app/api/tasks.py
+++ b/app/api/tasks.py
@@ -105,6 +105,17 @@ class TaskSerializer(serializers.ModelSerializer):
         exclude = ('orthophoto_extent', 'dsm_extent', 'dtm_extent', )
         read_only_fields = ('processing_time', 'status', 'last_error', 'created_at', 'pending_action', 'available_assets', 'size', )
 
+
+def check_processing_node_perms(request):
+    if request.data.get('processing_node'):
+        try:
+            pnode = ProcessingNode.objects.get(pk=int(request.data.get('processing_node')))
+            if not request.user.has_perm("view_processingnode", pnode):
+                raise Exception("Invalid")
+        except:
+            raise exceptions.ValidationError(detail=_("Cannot create task, processing node is not valid"))
+
+
 class TaskViewSet(viewsets.ViewSet):
     """
     Task get/add/delete/update
@@ -362,6 +373,9 @@ class TaskViewSet(viewsets.ViewSet):
     def create(self, request, project_pk=None):
         project = get_and_check_project(request, project_pk, ('change_project', ))
 
+        # Check if user has permissions to set processing node
+        check_processing_node_perms(request)
+
         # Check if an alignment field is set to a valid task
         # this means a user wants to align this task with another
         align_to = request.data.get('align_to')
@@ -414,6 +428,9 @@ class TaskViewSet(viewsets.ViewSet):
             check_project_perms(request, task.project, ('change_project', ))
         except (ObjectDoesNotExist, ValidationError):
             raise exceptions.NotFound()
+
+        # Check if user has permissions to set processing node
+        check_processing_node_perms(request)
 
         # Check that a user has access to reassign a project
         if 'project' in request.data:

--- a/app/models/task.py
+++ b/app/models/task.py
@@ -735,6 +735,11 @@ class Task(models.Model):
             if self.processing_node:
                 # Need to process some images (UUID not yet set and task doesn't have pending actions)?
                 if not self.uuid and self.pending_action is None and self.status is None:
+                    
+                    # Check that task's owner can use this processing ndoe
+                    if not self.project.owner.has_perm("view_processingnode", self.processing_node):
+                        raise NodeServerError(gettext("Invalid processing node selected"))
+                    
                     logger.info("Processing... {}".format(self))
 
                     images_path = self.task_path()

--- a/app/models/task.py
+++ b/app/models/task.py
@@ -736,10 +736,6 @@ class Task(models.Model):
                 # Need to process some images (UUID not yet set and task doesn't have pending actions)?
                 if not self.uuid and self.pending_action is None and self.status is None:
                     
-                    # Check that task's owner can use this processing ndoe
-                    if not self.project.owner.has_perm("view_processingnode", self.processing_node):
-                        raise NodeServerError(gettext("Invalid processing node selected"))
-                    
                     logger.info("Processing... {}".format(self))
 
                     images_path = self.task_path()

--- a/app/tests/test_api_export.py
+++ b/app/tests/test_api_export.py
@@ -61,12 +61,25 @@ class TestApiTask(BootTransactionTestCase):
             pnode = ProcessingNode.objects.create(hostname="localhost", port=11223)
             assign_perm('view_processingnode', user, pnode)
             assign_perm('view_processingnode', other_user, pnode)
+
+            other_pnode = ProcessingNode.objects.create(hostname="localhost", port=11224)
+            assign_perm('view_processingnode', other_user, other_pnode)
             
             # task creation via file upload
             image1 = open("app/fixtures/tiny_drone_image.jpg", 'rb')
             image2 = open("app/fixtures/tiny_drone_image_2.jpg", 'rb')
 
             client.login(username="testuser", password="test1234")
+
+            # Attempt to create a task with a processing node we have no access to
+            res = client.post("/api/projects/{}/tasks/".format(project.id), {
+                'images': [image1, image2],
+                'name': 'test task',
+                'processing_node': other_pnode.id
+            }, format="multipart")
+            self.assertTrue(res.status_code == status.HTTP_400_BAD_REQUEST)
+            image1.seek(0)
+            image2.seek(0)
 
             # Normal case with images[], name and processing node parameter
             res = client.post("/api/projects/{}/tasks/".format(project.id), {
@@ -96,11 +109,17 @@ class TestApiTask(BootTransactionTestCase):
                 res = client.post("/api/projects/{}/tasks/{}/{}/export".format(project.id, task.id, asset_type), data)
                 self.assertEqual(res.status_code, status.HTTP_404_NOT_FOUND)
 
+            # Assign invalid processing node to task via API
+            res = client.patch("/api/projects/{}/tasks/{}/".format(project.id, task.id), {
+                'processing_node': other_pnode.id
+            })
+            self.assertEqual(res.status_code, status.HTTP_400_BAD_REQUEST)
+
             # Assign processing node to task via API
             res = client.patch("/api/projects/{}/tasks/{}/".format(project.id, task.id), {
                 'processing_node': pnode.id
             })
-            self.assertTrue(res.status_code == status.HTTP_200_OK)
+            self.assertEqual(res.status_code, status.HTTP_200_OK)
 
             retry_count = 0
             while task.status != status_codes.COMPLETED:


### PR DESCRIPTION
Additional checks on whether a processing node can be used for processing. (optional)