### PR TITLE
Set same-site: None cookie over secure contexts on iframe pages

### DIFF
--- a/app/views/public.py
+++ b/app/views/public.py
@@ -7,7 +7,7 @@ from django.shortcuts import render
 
 from app.api.tasks import TaskSerializer
 from app.models import Basemap
-from app.views.utils import get_permissions, get_task_or_raise, get_project_or_raise, handle_302
+from app.views.utils import get_permissions, get_task_or_raise, get_project_or_raise, handle_302, csrf_samesite_none_if_secure
 from django.views.decorators.csrf import ensure_csrf_cookie
 from webodm import settings
 
@@ -65,6 +65,7 @@ def handle_map(request, template, uuid_type=None, uuid=None, hide_title=False):
 def map(request, uuid_type=None, uuid=None):
     return handle_map(request, 'app/public/map.html', uuid_type, uuid, False)
 
+@csrf_samesite_none_if_secure
 def map_iframe(request, uuid_type=None, uuid=None):
     return handle_map(request, 'app/public/map_iframe.html', uuid_type, uuid, True)
 

--- a/app/views/utils.py
+++ b/app/views/utils.py
@@ -22,6 +22,19 @@ def ResponseClusterRedirect(request, to_cluster):
 def cluster_mode():
     return settings.CLUSTER_ID is not None
 
+def csrf_samesite_none_if_secure(func):
+    # Set same-site None for secure connections when using iframes
+    # otherwise the CSRF cookie is not sent
+    @wraps(func)
+    def wrap(request, *args, **kwargs):
+        response = func(request, *args, **kwargs)
+        if "csrftoken" in response.cookies and \
+           "secure" in response.cookies["csrftoken"] and response.cookies["csrftoken"]["secure"] and \
+           "samesite" in response.cookies["csrftoken"] and response.cookies["csrftoken"]["samesite"] == "Lax":
+            response.cookies["csrftoken"]["samesite"] = "None"
+        return response
+    return wrap
+
 def handle_302(func):
     @wraps(func)
     def wrap(request, *args, **kwargs):


### PR DESCRIPTION
This fixes a problem with CSRF cookies not being properly set when the map view page is accessed from an embedded iframe and a user attempts to use the map tools.