### PR TITLE
Bump eventlet on Windows

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -58,7 +58,7 @@ https://github.com/WebODM/WebODM/releases/download/v3.0.0/rasterio-1.3.10.post1.
 https://github.com/WebODM/WebODM/releases/download/v1.9.7/rasterio-1.2.10-cp39-cp39-win_amd64.whl ; sys_platform == "win32"
 https://github.com/WebODM/WebODM/releases/download/v1.9.7/GDAL-3.3.3-cp39-cp39-win_amd64.whl ; sys_platform == "win32"
 Shapely==1.8.0 ; sys_platform == "win32"
-eventlet==0.33.3 ; sys_platform == "win32"
+eventlet==0.41.0 ; sys_platform == "win32"
 pyopenssl==24.0.0 ; sys_platform == "win32"
 numpy==1.26.2
 scipy==1.11.3


### PR DESCRIPTION
Updates to latest to avoid issues with network name resolution on certain Windows machines.