### PR TITLE
Add Podman compatibility to webodm.sh and Compose files

### DIFF
--- a/docker-compose.nodeodm.gpu.nvidia.podman.yml
+++ b/docker-compose.nodeodm.gpu.nvidia.podman.yml
@@ -1,15 +1,16 @@
 # Podman-compatible alternative to docker-compose.nodeodm.gpu.nvidia.yml.
 #
 # The Docker variant requests the GPU via the Compose Spec's
-# `deploy.resources.reservations.devices` block (driver: nvidia), which relies
-# on the nvidia-container-toolkit runtime and isn't understood by Podman's
-# Docker-API compatibility layer. Podman instead exposes GPUs through the
-# Container Device Interface (CDI), referenced here the same way this
-# project's own devcontainer does it (see .devcontainer/devcontainer.json's
+# `deploy.resources.reservations.devices` block (driver: nvidia), which needs
+# the nvidia-container-toolkit runtime and isn't understood by Podman. Podman
+# resolves GPUs through the Container Device Interface (CDI) instead, the same
+# way this project's own devcontainer does it (see .devcontainer/devcontainer.json's
 # `--device nvidia.com/gpu=all`).
 #
-# webodm.sh selects this file instead of docker-compose.nodeodm.gpu.nvidia.yml
-# when it detects the active container engine is Podman.
+# webodm.sh picks this file over docker-compose.nodeodm.gpu.nvidia.yml when
+# podman-compose is the resolved compose backend (see uses_podman_compose()
+# in webodm.sh; CDI resolution needs podman-compose talking to Podman
+# directly, not just any engine running under Podman).
 version: '2.1'
 services:
   webapp:

--- a/docker-compose.nodeodm.gpu.nvidia.podman.yml
+++ b/docker-compose.nodeodm.gpu.nvidia.podman.yml
@@ -1,0 +1,28 @@
+# Podman-compatible alternative to docker-compose.nodeodm.gpu.nvidia.yml.
+#
+# The Docker variant requests the GPU via the Compose Spec's
+# `deploy.resources.reservations.devices` block (driver: nvidia), which relies
+# on the nvidia-container-toolkit runtime and isn't understood by Podman's
+# Docker-API compatibility layer. Podman instead exposes GPUs through the
+# Container Device Interface (CDI), referenced here the same way this
+# project's own devcontainer does it (see .devcontainer/devcontainer.json's
+# `--device nvidia.com/gpu=all`).
+#
+# webodm.sh selects this file instead of docker-compose.nodeodm.gpu.nvidia.yml
+# when it detects the active container engine is Podman.
+version: '2.1'
+services:
+  webapp:
+    depends_on:
+      - node-odx-1
+    environment:
+      - WO_DEFAULT_NODES
+  node-odx-1:
+    image: webodm/nodeodx:gpu
+    container_name: node-odx-1
+    expose:
+      - "3000"
+    restart: unless-stopped
+    oom_score_adj: 500
+    devices:
+      - nvidia.com/gpu=all

--- a/docker-compose.settings.yml
+++ b/docker-compose.settings.yml
@@ -2,7 +2,7 @@ version: '2.1'
 services:
   webapp:
     volumes:
-      - ${WO_SETTINGS}:/webodm/webodm/settings_override.py
+      - ${WO_SETTINGS}:/webodm/webodm/settings_override.py:z
   worker:
     volumes:
-      - ${WO_SETTINGS}:/webodm/webodm/settings_override.py
+      - ${WO_SETTINGS}:/webodm/webodm/settings_override.py:z

--- a/docker-compose.ssl-manual.yml
+++ b/docker-compose.ssl-manual.yml
@@ -3,5 +3,5 @@ version: '2.1'
 services:
   webapp:
     volumes:
-      - ${WO_SSL_KEY}:/webodm/nginx/ssl/key.pem
-      - ${WO_SSL_CERT}:/webodm/nginx/ssl/cert.pem
+      - ${WO_SSL_KEY}:/webodm/nginx/ssl/key.pem:Z
+      - ${WO_SSL_CERT}:/webodm/nginx/ssl/cert.pem:Z

--- a/webodm.sh
+++ b/webodm.sh
@@ -215,20 +215,34 @@ usage(){
   exit
 }
 
+is_podman(){
+	# Detects whether the active container engine is Podman, whether that's
+	# a native podman/podman-compose install, or a Docker CLI pointed (via
+	# DOCKER_HOST) at a podman socket. Used to pick podman-compatible compose
+	# files/behavior where Docker and Podman aren't drop-in compatible.
+	if command -v docker >/dev/null 2>&1; then
+		docker version 2>/dev/null | grep -qi "Podman Engine" && return 0
+		return 1
+	elif command -v podman >/dev/null 2>&1; then
+		return 0
+	fi
+	return 1
+}
+
 detect_gpus(){
 	# export GPU_AMD=false
 	export GPU_NVIDIA=false
 
 	if [ "${platform}" = "Linux" ]; then
 		set +e
-		if lspci | grep 'NVIDIA'; then
+		if command -v lspci >/dev/null 2>&1 && lspci | grep 'NVIDIA'; then
 			echo "GPU_NVIDIA has been found"
 			export GPU_NVIDIA=true
 			set -e
 			return
 		fi
 
-		if lspci | grep "VGA.*NVIDIA"; then
+		if command -v lspci >/dev/null 2>&1 && lspci | grep "VGA.*NVIDIA"; then
 			echo "GPU_NVIDIA has been found"
 			export GPU_NVIDIA=true
 			set -e
@@ -275,7 +289,13 @@ check_docker_compose(){
 		# Check if compose plugin is installed
 		if ! docker compose > /dev/null 2>&1; then
 
-			if [ "${platform}" = "Linux" ] && [ -z "$1" ] && [ ! -z "$HOME" ]; then
+			# Fall back to podman-compose on Podman hosts that don't have a
+			# docker/compose-plugin shim installed (the auto-install below
+			# assumes a `docker` CLI exists to host the plugin, which isn't
+			# true on a podman-only host).
+			if command -v podman-compose >/dev/null 2>&1; then
+				docker_compose="podman-compose"
+			elif [ "${platform}" = "Linux" ] && [ -z "$1" ] && [ ! -z "$HOME" ]; then
 				echo -e "Checking for docker compose... \033[93mnot found, we'll attempt to install it\033[39m"
 				check_command "curl" "Cannot automatically install docker compose. Please visit https://docs.docker.com/compose/install/" "" "silent"
 				DOCKER_CONFIG=${DOCKER_CONFIG:-$HOME/.docker}
@@ -346,7 +366,13 @@ environment_check(){
         fi
     fi
     
-    check_command "docker" "https://www.docker.com/"
+    if command -v docker >/dev/null 2>&1; then
+        check_command "docker" "https://www.docker.com/"
+    elif command -v podman >/dev/null 2>&1; then
+        echo -e "Checking for docker...  \033[93mnot found, but podman is available, continuing\033[39m"
+    else
+        check_command "docker" "https://www.docker.com/ (or install Podman: https://podman.io/)"
+    fi
     check_docker_compose
 
     if [[ $WO_DEBUG = "YES" ]]; then
@@ -363,7 +389,11 @@ environment_check(){
             fi
 
         fi
-        DOCKER_VERSION=$(docker --version)
+        if command -v docker >/dev/null 2>&1; then
+            DOCKER_VERSION=$(docker --version)
+        elif command -v podman >/dev/null 2>&1; then
+            DOCKER_VERSION=$(podman --version)
+        fi
         # remove stderr in case podman throws complaints, ensure only compose ver is taken
         COMPOSE_VERSION=$($docker_compose version 2> /dev/null | head -n 1)
         echo "Docker version: $DOCKER_VERSION"
@@ -432,7 +462,11 @@ start(){
 
     if [[ $WO_DEFAULT_NODES -gt 0 ]]; then
 		if [ "${GPU_NVIDIA}" = true ]; then
-			command+=" -f docker-compose.nodeodm.gpu.nvidia.yml"
+			if is_podman; then
+				command+=" -f docker-compose.nodeodm.gpu.nvidia.podman.yml"
+			else
+				command+=" -f docker-compose.nodeodm.gpu.nvidia.yml"
+			fi
 		else
 			command+=" -f docker-compose.nodeodm.yml"
 		fi
@@ -521,7 +555,11 @@ down(){
 	command="$docker_compose -f docker-compose.yml"
 
 	if [ "${GPU_NVIDIA}" = true ]; then
-		command+=" -f docker-compose.nodeodm.gpu.nvidia.yml"
+		if is_podman; then
+			command+=" -f docker-compose.nodeodm.gpu.nvidia.podman.yml"
+		else
+			command+=" -f docker-compose.nodeodm.gpu.nvidia.yml"
+		fi
 	else
 		command+=" -f docker-compose.nodeodm.yml"
 	fi
@@ -543,7 +581,8 @@ rebuild(){
 run_tests(){
     # If in a container, we run the actual test commands
     # otherwise we launch this command from the container
-    if [[ -f /.dockerenv ]]; then
+    # (/run/.containerenv is Podman's equivalent of Docker's /.dockerenv)
+    if [[ -f /.dockerenv || -f /run/.containerenv ]]; then
         test_type=${1:-"all"}
         shift || true
         
@@ -610,7 +649,11 @@ update(){
 
 	if [[ $WO_DEFAULT_NODES -gt 0 ]]; then
 		if [ "${GPU_NVIDIA}" = true ]; then
-			command+=" -f docker-compose.nodeodm.gpu.nvidia.yml"
+			if is_podman; then
+				command+=" -f docker-compose.nodeodm.gpu.nvidia.podman.yml"
+			else
+				command+=" -f docker-compose.nodeodm.gpu.nvidia.yml"
+			fi
 		else
 			command+=" -f docker-compose.nodeodm.yml"
 		fi
@@ -634,11 +677,15 @@ elif [[ $1 = "stop" ]]; then
 	command="$docker_compose -f docker-compose.yml"
 
 	if [ "${GPU_NVIDIA}" = true ]; then
-		command+=" -f docker-compose.nodeodm.gpu.nvidia.yml"
+		if is_podman; then
+			command+=" -f docker-compose.nodeodm.gpu.nvidia.podman.yml"
+		else
+			command+=" -f docker-compose.nodeodm.gpu.nvidia.yml"
+		fi
 	else
 		command+=" -f docker-compose.nodeodm.yml"
 	fi
- 
+
 	command+=" -f docker-compose.nodemicmac.yml stop"
 	run "${command}"
 elif [[ $1 = "restart" ]]; then

--- a/webodm.sh
+++ b/webodm.sh
@@ -229,6 +229,19 @@ is_podman(){
 	return 1
 }
 
+uses_podman_compose(){
+	# NVIDIA GPU passthrough needs Podman's CDI device resolution
+	# (nvidia.com/gpu=all), which only happens when podman-compose talks to
+	# Podman directly. Going through the generic Docker-compatible REST API
+	# (docker CLI / docker-compose / docker compose plugin, even when pointed
+	# at a podman socket via DOCKER_HOST) does not resolve CDI device
+	# strings -- and, tested directly, silently starts the GPU node without
+	# any GPU wired in at all rather than erroring. So GPU compose file
+	# selection must key off the actual resolved compose backend, not merely
+	# "is the engine podman" (see is_podman() above, used for other checks).
+	[[ "$docker_compose" == "podman-compose" ]]
+}
+
 detect_gpus(){
 	# export GPU_AMD=false
 	export GPU_NVIDIA=false
@@ -462,9 +475,12 @@ start(){
 
     if [[ $WO_DEFAULT_NODES -gt 0 ]]; then
 		if [ "${GPU_NVIDIA}" = true ]; then
-			if is_podman; then
+			if uses_podman_compose; then
 				command+=" -f docker-compose.nodeodm.gpu.nvidia.podman.yml"
 			else
+				if is_podman; then
+					echo -e "\033[91mWARNING:\033[39m GPU passthrough for the default node is not reliably supported when accessing Podman through the Docker-compatible API ($docker_compose). The GPU node container may start without any GPU actually wired in. Install podman-compose and re-run for working GPU passthrough, see https://docs.webodm.org/tutorials/using-podman/ for more information.\033[39m"
+				fi
 				command+=" -f docker-compose.nodeodm.gpu.nvidia.yml"
 			fi
 		else
@@ -555,7 +571,7 @@ down(){
 	command="$docker_compose -f docker-compose.yml"
 
 	if [ "${GPU_NVIDIA}" = true ]; then
-		if is_podman; then
+		if uses_podman_compose; then
 			command+=" -f docker-compose.nodeodm.gpu.nvidia.podman.yml"
 		else
 			command+=" -f docker-compose.nodeodm.gpu.nvidia.yml"
@@ -649,7 +665,7 @@ update(){
 
 	if [[ $WO_DEFAULT_NODES -gt 0 ]]; then
 		if [ "${GPU_NVIDIA}" = true ]; then
-			if is_podman; then
+			if uses_podman_compose; then
 				command+=" -f docker-compose.nodeodm.gpu.nvidia.podman.yml"
 			else
 				command+=" -f docker-compose.nodeodm.gpu.nvidia.yml"
@@ -677,7 +693,7 @@ elif [[ $1 = "stop" ]]; then
 	command="$docker_compose -f docker-compose.yml"
 
 	if [ "${GPU_NVIDIA}" = true ]; then
-		if is_podman; then
+		if uses_podman_compose; then
 			command+=" -f docker-compose.nodeodm.gpu.nvidia.podman.yml"
 		else
 			command+=" -f docker-compose.nodeodm.gpu.nvidia.yml"

--- a/webodm.sh
+++ b/webodm.sh
@@ -216,10 +216,10 @@ usage(){
 }
 
 is_podman(){
-	# Detects whether the active container engine is Podman, whether that's
-	# a native podman/podman-compose install, or a Docker CLI pointed (via
-	# DOCKER_HOST) at a podman socket. Used to pick podman-compatible compose
-	# files/behavior where Docker and Podman aren't drop-in compatible.
+	# True whether Podman is a native podman/podman-compose install, or a
+	# Docker CLI pointed (via DOCKER_HOST) at a podman socket. Used for
+	# messaging (environment_check) and the GPU warning below, not for
+	# picking the GPU compose file itself; see uses_podman_compose().
 	if command -v docker >/dev/null 2>&1; then
 		docker version 2>/dev/null | grep -qi "Podman Engine" && return 0
 		return 1
@@ -230,15 +230,13 @@ is_podman(){
 }
 
 uses_podman_compose(){
-	# NVIDIA GPU passthrough needs Podman's CDI device resolution
-	# (nvidia.com/gpu=all), which only happens when podman-compose talks to
-	# Podman directly. Going through the generic Docker-compatible REST API
-	# (docker CLI / docker-compose / docker compose plugin, even when pointed
-	# at a podman socket via DOCKER_HOST) does not resolve CDI device
-	# strings -- and, tested directly, silently starts the GPU node without
-	# any GPU wired in at all rather than erroring. So GPU compose file
-	# selection must key off the actual resolved compose backend, not merely
-	# "is the engine podman" (see is_podman() above, used for other checks).
+	# GPU passthrough needs Podman's CDI device resolution (nvidia.com/gpu=all),
+	# which only happens when podman-compose talks to Podman directly. The
+	# generic Docker-compatible REST API (docker CLI, docker-compose, or the
+	# docker compose plugin, even against a podman socket) doesn't resolve CDI
+	# device strings, and tested directly, it doesn't error either: the GPU
+	# node container starts with no GPU wired in at all. So GPU compose file
+	# selection has to key off the actual resolved backend, not is_podman().
 	[[ "$docker_compose" == "podman-compose" ]]
 }
 

--- a/webodm.sh
+++ b/webodm.sh
@@ -408,7 +408,11 @@ environment_check(){
             DOCKER_VERSION=$(podman --version)
         fi
         # remove stderr in case podman throws complaints, ensure only compose ver is taken
-        COMPOSE_VERSION=$($docker_compose version 2> /dev/null | head -n 1)
+        # (`|| true` guards against SIGPIPE: podman-compose's multi-line
+        # output makes `head -n 1` close the pipe early, and under
+        # `set -o pipefail` that non-zero status would otherwise kill the
+        # whole script over what's just a cosmetic version printout)
+        COMPOSE_VERSION=$($docker_compose version 2> /dev/null | head -n 1) || true
         echo "Docker version: $DOCKER_VERSION"
         echo "Compose version: $COMPOSE_VERSION"
         if [ -z "$DOCKER_HOST" ]; then


### PR DESCRIPTION
## Problem
`webodm.sh` and several Compose files assume a Docker environment. Running the stack under Podman fails or misbehaves in a few places:

- `check_docker_compose` and `environment_check` require a Docker CLI. They don't fall back to podman-compose on a Podman-only host.
- GPU passthrough used Docker's `deploy.resources.reservations.devices` block. Podman doesn't support that block. It resolves GPUs through CDI syntax instead (`nvidia.com/gpu=all`) and only when podman-compose talks to Podman directly. A Docker CLI pointed at a Podman socket doesn't resolve CDI devices, and the failure is silent: the GPU node container starts with no GPU wired in.
- Bind mounts in `docker-compose.settings.yml` and `docker-compose.ssl-manual.yml` need `:z/:Z` SELinux relabel suffixes to be readable under Podman with SELinux enforcing.
- `run_tests` only checked for `/.dockerenv` to detect that it's running inside a container. Podman uses `/run/.containerenv` instead.
- The Compose version check crashed with SIGPIPE under `set -o pipefail` because `head -n1` closes the pipe early against podman-compose's multi-line version output.

## Solution
- Detect Podman and fall back to podman-compose when no Docker or compose-plugin shim is present.
- Pick the GPU compose file based on the resolved compose backend (`uses_podman_compose`), not just whether Podman is present. Added `docker-compose.nodeodm.gpu.nvidia.podman.yml`, which uses CDI device syntax.
- Added `:z/:Z` suffixes to the two affected bind mounts.
- Check `/run/.containerenv` alongside `/.dockerenv` in `run_tests`.
- Guard the version-check pipeline with `|| true` so the SIGPIPE no longer kills the script.

Docker-only setups keep their existing behavior. The new logic only branches when Podman is the resolved backend.

## Testing
1. Removed Podman-Docker compatibility layer.
2. Removed all containers, volumes, and images.
3. Ran `./webodm start --gpu` with preset `.env` data locations.
4. Processed a [dataset](https://github.com/OpenDroneMap/odm_data_helenenschacht/tree/main) with the `3D Model` preset.
5. Ensured GPU was used.

It should be tested in a Docker engine environment to confirm no regressions.