### PR TITLE
measure: split volume into cut/fill/net, add DSM/DTM model selection

### DIFF
--- a/coreplugins/measure/api.py
+++ b/coreplugins/measure/api.py
@@ -13,23 +13,31 @@ from .volume import calc_volume
 class VolumeRequestSerializer(serializers.Serializer):
     area = serializers.JSONField(help_text="GeoJSON Polygon contour defining the volume area to compute")
     method = serializers.CharField(help_text="One of: [plane,triangulate,average,custom,highest,lowest]", default="triangulate", allow_blank=True)
+    dem_type = serializers.ChoiceField(choices=["dsm", "dtm"], help_text="Which elevation model to compute the volume against", default="dsm")
 
 class TaskVolume(TaskView):
     def post(self, request, pk=None):
         task = self.get_and_check_task(request, pk)
-        if task.dsm_extent is None:
-            return Response({'error': _('No surface model available. From the Dashboard, select this task, press Edit, from the options make sure to check "dsm", then press Restart --> From DEM.')})
 
         serializer = VolumeRequestSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
 
         area = serializer['area'].value
         method = serializer['method'].value
-        points = [coord for coord in area['geometry']['coordinates'][0]]
-        dsm = os.path.abspath(task.get_asset_download_path("dsm.tif"))
+        dem_type = serializer['dem_type'].value
 
-        try: 
-            celery_task_id = run_function_async(calc_volume, input_dem=dsm, pts=points, pts_epsg=4326, base_method=method).task_id
+        if dem_type == "dtm":
+            if task.dtm_extent is None:
+                return Response({'error': _('No terrain model available. From the Dashboard, select this task, press Edit, from the options make sure to check "dtm", then press Restart --> From DEM.')})
+        else:
+            if task.dsm_extent is None:
+                return Response({'error': _('No surface model available. From the Dashboard, select this task, press Edit, from the options make sure to check "dsm", then press Restart --> From DEM.')})
+
+        points = [coord for coord in area['geometry']['coordinates'][0]]
+        dem = os.path.abspath(task.get_asset_download_path(f"{dem_type}.tif"))
+
+        try:
+            celery_task_id = run_function_async(calc_volume, input_dem=dem, pts=points, pts_epsg=4326, base_method=method).task_id
             return Response({'celery_task_id': celery_task_id}, status=status.HTTP_200_OK)
         except Exception as e:
             return Response({'error': str(e)}, status=status.HTTP_200_OK)

--- a/coreplugins/measure/public/MeasurePopup.jsx
+++ b/coreplugins/measure/public/MeasurePopup.jsx
@@ -32,6 +32,7 @@ export default class MeasurePopup extends React.Component {
         volume: null, // to be calculated,
         baseMethod: localStorage.getItem("measure_base_method") || "triangulate",
         task: null,
+        demType: "dsm",
         error: ""
     };
 
@@ -58,8 +59,11 @@ export default class MeasurePopup extends React.Component {
     };
     
     if (this.state.volume !== null && this.state.volume !== false){
-        result.Volume = us.volume(this.state.volume).value;
+        result.Cut = us.volume(this.state.volume.cut).value;
+        result.Fill = us.volume(this.state.volume.fill).value;
+        result.Net = us.volume(this.state.volume.net).value;
         result.BaseSurface = this.state.baseMethod;
+        result.Model = this.state.demType;
     }
 
     result.UnitSystem = this.lastUnitSystem;
@@ -102,7 +106,8 @@ export default class MeasurePopup extends React.Component {
         const layer = layers[layers.length - 1];
         const meta = layer[Symbol.for("meta")];
         if (meta){
-            this.setState({task: meta.task});
+            const demType = meta.type === "dtm" ? "dtm" : "dsm";
+            this.setState({task: meta.task, demType});
             setTimeout(() => {
               this.recalculateVolume();
             }, 0);
@@ -116,7 +121,7 @@ export default class MeasurePopup extends React.Component {
   }
 
   recalculateVolume = () => {
-    const { task, baseMethod } = this.state;
+    const { task, baseMethod, demType } = this.state;
     if (!task) return;
 
     this.setState({volume: null, error: ""});
@@ -126,7 +131,8 @@ export default class MeasurePopup extends React.Component {
         url: `/api/plugins/measure/task/${task.id}/volume`,
         data: JSON.stringify({
           area: this.props.resultFeature.toGeoJSON(14),
-          method: baseMethod
+          method: baseMethod,
+          dem_type: demType
         }),
         contentType: "application/json"
     }).done(result => {
@@ -136,7 +142,7 @@ export default class MeasurePopup extends React.Component {
               else{
                   Workers.getOutput(result.celery_task_id, (error, volume) => {
                       if (error) this.setState({error});
-                      else this.setState({volume: parseFloat(volume)});
+                      else this.setState({volume});
                   }, `/api/plugins/measure/task/${task.id}/volume/get/`);
               }
             });
@@ -185,13 +191,16 @@ export default class MeasurePopup extends React.Component {
         {featureType == "Polygon" && <p>{_("Perimeter:")} {this.props.model.lengthDisplay}</p>}
         {featureType == "Polygon" && <p>{_("Area:")} {this.props.model.areaDisplay}</p>}
         {featureType == "Polygon" && volume === null && !error && <p>{_("Volume:")} <i>{_("computing…")}</i> <i className="fa fa-cog fa-spin fa-fw" /></p>}
-        {typeof volume === "number" ? 
+        {volume && typeof volume === "object" ?
             [
-              <p>{_("Volume:")} {us.volume(volume).toString()}</p>,
-              <p className="base-control">{_("Base surface:")} 
+              <p key="model">{_("Model:")} {this.state.demType === "dtm" ? _("Terrain (DTM)") : _("Surface (DSM)")}</p>,
+              <p key="cut">{_("Cut:")} {us.volume(volume.cut).toString()}</p>,
+              <p key="fill">{_("Fill:")} {us.volume(volume.fill).toString()}</p>,
+              <p key="net">{_("Net:")} {us.volume(volume.net).toString()}</p>,
+              <p key="base-control" className="base-control">{_("Base surface:")}
                 <select className="form-control" value={this.state.baseMethod} onChange={this.handleBaseMethodChange}>
-                  {baseMethods.map(bm => 
-                      <option key={bm.method} 
+                  {baseMethods.map(bm =>
+                      <option key={bm.method}
                               value={bm.method}>{bm.label}</option>)}
                 </select>
               </p>

--- a/coreplugins/measure/public/MeasurePopup.scss
+++ b/coreplugins/measure/public/MeasurePopup.scss
@@ -3,9 +3,14 @@
         margin: 0;
     }
 
+    .error{
+        overflow-wrap: break-word;
+        word-break: break-word;
+        display: block;
+    }
+
     .error.long{
         overflow: scroll;
-        display: block;
         max-height: 200px;
     }
 

--- a/coreplugins/measure/volume.py
+++ b/coreplugins/measure/volume.py
@@ -104,8 +104,11 @@ def calc_volume(input_dem, pts=None, pts_epsg=None, geojson_polygon=None, decima
 
             # Calculate volume
             diff = rast_dem - base
-            volume = np.nansum(diff) * px_area
-            volume *= to_meter ** 3
+            factor = px_area * (to_meter ** 3)
+
+            fill = np.nansum(diff[diff > 0]) * factor  # Material above the base surface
+            cut = -np.nansum(diff[diff < 0]) * factor  # Material below the base surface
+            net = fill - cut
 
             # import matplotlib.pyplot as plt
             # fig, ax = plt.subplots()
@@ -115,7 +118,11 @@ def calc_volume(input_dem, pts=None, pts_epsg=None, geojson_polygon=None, decima
             # plt.title('Debug')
             # plt.show()
 
-            return {'output': np.abs(np.round(volume, decimals=decimals))}
+            return {'output': {
+                'cut': float(np.round(cut, decimals=decimals)),
+                'fill': float(np.round(fill, decimals=decimals)),
+                'net': float(np.round(net, decimals=decimals))
+            }}
     except Exception as e:
         return {'error': str(e)}
 


### PR DESCRIPTION
The measure plugin previously calculated volume as the absolute value of the sum of cut and fill. It also incorrectly used the Digital Surface Model data for this calculation, even when the user had selected DTM as the visible layer. 

Now the Measure results show

- which model is being measured (DSM or DTM)
- Cut (material below the plane)
- Fill (material above the plane)
- Net (fill - cut (signed) ) 

summary of changes to files: 

MeasurePopup now determines which model to use and sends it with the volume call. it also displays all of the new information listed above. 

dem_type parameter ("dim"/"dtm")  was added to TaskVolume, which verifies that the resource exists and sends it with the calc_volume call.

calc_volume now calculates and returns cut, fill and net individually 

